### PR TITLE
Readme example small errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ TouchID.authenticate()
   .catch(error => {
     // Failure code
   });
-});
 ```
 
 ## Example
@@ -66,8 +65,7 @@ var YourComponent = React.createClass({
       <View>
         ...
         <TouchableHighlight
-          onPress={this._pressHandler}
-        />
+          onPress={this._pressHandler}>
           <Text>
             Authenticate with Touch ID
           </Text>
@@ -94,7 +92,6 @@ TouchID.authenticate()
     // Failure code
     console.log(error);
   });
-});
 ```
 
 ### isSupported()
@@ -112,7 +109,6 @@ TouchID.isSupported()
     // Failure code
     console.log(error);
   });
-});
 ```
 
 ## Errors


### PR DESCRIPTION
When I tried this module this morning I discovered a few little typos in the examples which resulted in a few red screens. I know it is not that important but it is a quick fix. 

I fixed the two authenticate examples, the isSupported example and the main example. The authenticate and the isSupported examples had a `});` to much. The main example closed the TouchableHighlight to early.

And if I may suggest: 
* It would be nice to add some style to the TouchableHighlight so that it is visible when someone tries out the example code. 
* I know that the three dots in the main example are representing some other code but it will cause an error.

What are you thoughts on this?

Btw: Thank you for creating this module! I am planning on using it in my app.