### PR TITLE
allow fallback to passcode if touchID is not enabled, enrolled or available

### DIFF
--- a/TouchID.ios.js
+++ b/TouchID.ios.js
@@ -29,7 +29,7 @@ var TouchID = {
     });
   },
 
-  authenticate(reason) {
+  authenticate(reason, fallback) {
     var authReason;
 
     // Set auth reason
@@ -41,7 +41,7 @@ var TouchID = {
     }
 
     return new Promise(function(resolve, reject) {
-      NativeTouchID.authenticate(authReason, function(error) {
+      NativeTouchID.authenticate(authReason, fallback, function(error) {
         // Return error if rejected
         if (error) {
           return reject(createError(error.message));

--- a/TouchID.m
+++ b/TouchID.m
@@ -4,10 +4,6 @@
 
 @implementation TouchID
 
-NSString *const keychainItemIdentifier = @"react-native-touch-id-passcode-trigger";
-NSString *const keychainItemServiceName = @"react-native-touch-id";
-BOOL storedDummy = false;
-
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(isSupported: (RCTResponseSenderBlock)callback)
@@ -28,34 +24,49 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
             fallbackToPasscode: (BOOL) fallbackToPasscode
                       callback: (RCTResponseSenderBlock)callback)
 {
-    [self authenticateWithTouchID:reason completionHandler:^(NSInteger errorCode, NSString* errorReason) {
+    [self authenticateWithPolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+                          reason:reason
+               completionHandler:^(NSInteger errorCode, NSString* errorReason) {
+
         if (errorCode == errSecSuccess) {
             callback(@[[NSNull null], @"Authenticated with Touch ID."]);
             return;
         }
 
         // check if we can fallback
-        if (fallbackToPasscode &&
-            (errorCode == LAErrorTouchIDNotAvailable || errorCode == LAErrorTouchIDNotEnrolled)) {
-            [self fallbackToPasscode:reason errorReason:errorReason callback:callback];
+        if (!fallbackToPasscode || (
+             errorCode != LAErrorTouchIDNotAvailable &&
+             errorCode != LAErrorTouchIDNotEnrolled
+            )) {
+            callback(@[RCTMakeError(errorReason, nil, nil)]);
             return;
         }
 
-        callback(@[RCTMakeError(errorReason, nil, nil)]);
+        [self authenticateWithPolicy:LAPolicyDeviceOwnerAuthentication
+                              reason:reason
+                   completionHandler:^(NSInteger errorCode, NSString *errorReason) {
+
+            if (errorCode == errSecSuccess) {
+                callback(@[[NSNull null], @"Authenticated with passcode."]);
+                return;
+            }
+
+            callback(@[RCTMakeError(errorReason, nil, nil)]);
+        }];
     }];
 }
 
-- (void) authenticateWithTouchID:(NSString *)reason
-                    completionHandler:(void(^) (NSInteger, NSString *))handler
+- (void) authenticateWithPolicy:(LAPolicy) policy
+               reason:(NSString *)reason
+    completionHandler:(void(^) (NSInteger, NSString *))handler
 {
     LAContext *context = [[LAContext alloc] init];
     __block NSString* errorReason;
     NSError* error;
 
-    // Device has TouchID
-    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
+    if ([context canEvaluatePolicy:policy error:&error]) {
         // Attempt Authentification
-        [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+        [context evaluatePolicy:policy
                 localizedReason:reason
                           reply:^(BOOL success, NSError *error)
          {
@@ -90,6 +101,9 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
                          errorReason = @"LAErrorTouchIDNotEnrolled";
                          break;
 
+                     case LAErrorTouchIDLockout:
+                         errorReason = @"LAErrorTouchIDLockout";
+                         break;
                      default:
                          errorReason = @"RCTTouchIDUnknownError";
                          break;
@@ -104,81 +118,20 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
              // Authenticated Successfully
          }];
 
-        // Device does not support TouchID
     } else {
-        handler(LAErrorTouchIDNotAvailable, @"RCTTouchIDNotSupported");
-    }
-}
-
-- (void) fallbackToPasscode:(NSString*) reason
-                errorReason:(NSString*) errorReason
-                  callback: (RCTResponseSenderBlock) callback
-{
-    // technique + code from: https://www.secsign.com/fingerprint-validation-as-an-alternative-to-passcodes/
-    if (![self storeDummyKeychainItem]) {
-        callback(@[RCTMakeError(errorReason, nil, nil)]);
-        return;
-    }
-
-    // The keychain operation shall be performed by the global queue. Otherwise it might just not happen.
-    dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void) {
-
-        // Create the keychain query attributes using the values from the first part of the code.
-        NSMutableDictionary * query = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
-                                       (__bridge id)(kSecClassGenericPassword), kSecClass,
-                                       keychainItemIdentifier, kSecAttrAccount,
-                                       keychainItemServiceName, kSecAttrService,
-                                       reason, kSecUseOperationPrompt,
-                                       nil];
-
-        // Start the query and the fingerprint scan and/or device passcode validation
-        CFTypeRef result = nil;
-        OSStatus authStatus = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
-
-        // Ignore the found content of the key chain entry (the dummy password) and only evaluate the return code.
-        if (authStatus == errSecSuccess) {
-            callback(@[[NSNull null], @"Executed fallback to passcode."]);
+        // Device does not support TouchID
+        NSInteger errCode;
+        NSString* errReason;
+        if (policy == LAPolicyDeviceOwnerAuthenticationWithBiometrics) {
+            errCode = LAErrorTouchIDNotAvailable;
+            errReason = @"RCTTouchIDNotSupported";
         } else {
-            callback(@[RCTMakeError(errorReason, nil, nil)]);
+            errCode = LAErrorAuthenticationFailed;
+            errReason = @"LAErrorAuthenticationFailed";
         }
-    });
-}
 
-- (BOOL) storeDummyKeychainItem
-{
-    if (storedDummy) return true;
-
-    // technique + code from: https://www.secsign.com/fingerprint-validation-as-an-alternative-to-passcodes/
-    NSData * pwData = [@"the password itself does not matter" dataUsingEncoding:NSUTF8StringEncoding];
-    NSMutableDictionary	* attributes = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
-                                        (__bridge id)(kSecClassGenericPassword), kSecClass,
-                                        keychainItemIdentifier, kSecAttrAccount,
-                                        keychainItemServiceName, kSecAttrService, nil];
-
-    // Require a fingerprint scan or passcode validation when the keychain entry is read.
-    CFErrorRef accessControlError = NULL;
-    SecAccessControlRef accessControlRef = SecAccessControlCreateWithFlags(
-                                                                           kCFAllocatorDefault,
-                                                                           kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-                                                                           kSecAccessControlUserPresence,
-                                                                           &accessControlError);
-
-    if (accessControlRef == NULL || accessControlError != NULL)
-    {
-        NSLog(@"Cannot create SecAccessControlRef to store a password with identifier “%@” in the key chain: %@.", keychainItemIdentifier, accessControlError);
-        return false;
+        handler(errCode, errReason);
     }
-
-    attributes[(__bridge id)kSecAttrAccessControl] = (__bridge id)accessControlRef;
-
-    // In case this code is executed again and the keychain item already exists we want an error code instead of a fingerprint scan.
-    attributes[(__bridge id)kSecUseNoAuthenticationUI] = @YES;
-    attributes[(__bridge id)kSecValueData] = pwData;
-
-    CFTypeRef result;
-    OSStatus osStatus = SecItemAdd((__bridge CFDictionaryRef)attributes, &result);
-    storedDummy = osStatus == errSecSuccess || osStatus == errSecDuplicateItem;
-    return storedDummy;
 }
 
 @end

--- a/TouchID.m
+++ b/TouchID.m
@@ -4,6 +4,10 @@
 
 @implementation TouchID
 
+NSString *const keychainItemIdentifier = @"react-native-touch-id-passcode-trigger";
+NSString *const keychainItemServiceName = @"react-native-touch-id";
+BOOL storedDummy = false;
+
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(isSupported: (RCTResponseSenderBlock)callback)
@@ -21,10 +25,32 @@ RCT_EXPORT_METHOD(isSupported: (RCTResponseSenderBlock)callback)
 }
 
 RCT_EXPORT_METHOD(authenticate: (NSString *)reason
+            fallbackToPasscode: (BOOL) fallbackToPasscode
                       callback: (RCTResponseSenderBlock)callback)
 {
+    [self authenticateWithTouchID:reason completionHandler:^(NSInteger errorCode, NSString* errorReason) {
+        if (errorCode == errSecSuccess) {
+            callback(@[[NSNull null], @"Authenticated with Touch ID."]);
+            return;
+        }
+
+        // check if we can fallback
+        if (fallbackToPasscode &&
+            (errorCode == LAErrorTouchIDNotAvailable || errorCode == LAErrorTouchIDNotEnrolled)) {
+            [self fallbackToPasscode:reason errorReason:errorReason callback:callback];
+            return;
+        }
+
+        callback(@[RCTMakeError(errorReason, nil, nil)]);
+    }];
+}
+
+- (void) authenticateWithTouchID:(NSString *)reason
+                    completionHandler:(void(^) (NSInteger, NSString *))handler
+{
     LAContext *context = [[LAContext alloc] init];
-    NSError *error;
+    __block NSString* errorReason;
+    NSError* error;
 
     // Device has TouchID
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
@@ -35,8 +61,6 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
          {
              // Failed Authentication
              if (error) {
-                 NSString *errorReason;
-
                  switch (error.code) {
                      case LAErrorAuthenticationFailed:
                          errorReason = @"LAErrorAuthenticationFailed";
@@ -72,19 +96,89 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
                  }
 
                  NSLog(@"Authentication failed: %@", errorReason);
-                 callback(@[RCTMakeError(errorReason, nil, nil)]);
+                 handler(error.code, errorReason);
                  return;
              }
 
+             handler(errSecSuccess, nil);
              // Authenticated Successfully
-             callback(@[[NSNull null], @"Authenticat with Touch ID."]);
          }];
 
         // Device does not support TouchID
     } else {
-        callback(@[RCTMakeError(@"RCTTouchIDNotSupported", nil, nil)]);
+        handler(LAErrorTouchIDNotAvailable, @"RCTTouchIDNotSupported");
+    }
+}
+
+- (void) fallbackToPasscode:(NSString*) reason
+                errorReason:(NSString*) errorReason
+                  callback: (RCTResponseSenderBlock) callback
+{
+    // technique + code from: https://www.secsign.com/fingerprint-validation-as-an-alternative-to-passcodes/
+    if (![self storeDummyKeychainItem]) {
+        callback(@[RCTMakeError(errorReason, nil, nil)]);
         return;
     }
+
+    // The keychain operation shall be performed by the global queue. Otherwise it might just not happen.
+    dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void) {
+
+        // Create the keychain query attributes using the values from the first part of the code.
+        NSMutableDictionary * query = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
+                                       (__bridge id)(kSecClassGenericPassword), kSecClass,
+                                       keychainItemIdentifier, kSecAttrAccount,
+                                       keychainItemServiceName, kSecAttrService,
+                                       reason, kSecUseOperationPrompt,
+                                       nil];
+
+        // Start the query and the fingerprint scan and/or device passcode validation
+        CFTypeRef result = nil;
+        OSStatus authStatus = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
+
+        // Ignore the found content of the key chain entry (the dummy password) and only evaluate the return code.
+        if (authStatus == errSecSuccess) {
+            callback(@[[NSNull null], @"Executed fallback to passcode."]);
+        } else {
+            callback(@[RCTMakeError(errorReason, nil, nil)]);
+        }
+    });
+}
+
+- (BOOL) storeDummyKeychainItem
+{
+    if (storedDummy) return true;
+
+    // technique + code from: https://www.secsign.com/fingerprint-validation-as-an-alternative-to-passcodes/
+    NSData * pwData = [@"the password itself does not matter" dataUsingEncoding:NSUTF8StringEncoding];
+    NSMutableDictionary	* attributes = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
+                                        (__bridge id)(kSecClassGenericPassword), kSecClass,
+                                        keychainItemIdentifier, kSecAttrAccount,
+                                        keychainItemServiceName, kSecAttrService, nil];
+
+    // Require a fingerprint scan or passcode validation when the keychain entry is read.
+    CFErrorRef accessControlError = NULL;
+    SecAccessControlRef accessControlRef = SecAccessControlCreateWithFlags(
+                                                                           kCFAllocatorDefault,
+                                                                           kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+                                                                           kSecAccessControlUserPresence,
+                                                                           &accessControlError);
+
+    if (accessControlRef == NULL || accessControlError != NULL)
+    {
+        NSLog(@"Cannot create SecAccessControlRef to store a password with identifier “%@” in the key chain: %@.", keychainItemIdentifier, accessControlError);
+        return false;
+    }
+
+    attributes[(__bridge id)kSecAttrAccessControl] = (__bridge id)accessControlRef;
+
+    // In case this code is executed again and the keychain item already exists we want an error code instead of a fingerprint scan.
+    attributes[(__bridge id)kSecUseNoAuthenticationUI] = @YES;
+    attributes[(__bridge id)kSecValueData] = pwData;
+
+    CFTypeRef result;
+    OSStatus osStatus = SecItemAdd((__bridge CFDictionaryRef)attributes, &result);
+    storedDummy = osStatus == errSecSuccess || osStatus == errSecDuplicateItem;
+    return storedDummy;
 }
 
 @end


### PR DESCRIPTION
stores keychain item accessible only with user presence (fingerprint / passcode). Technique + code taken from here: https://www.secsign.com/fingerprint-validation-as-an-alternative-to-passcodes/