### PR TITLE
Flow-type the reason argument of authenticate

### DIFF
--- a/TouchID.ios.js
+++ b/TouchID.ios.js
@@ -25,7 +25,7 @@ export default {
     });
   },
 
-  authenticate(reason) {
+  authenticate(reason /* ::?: string */) {
     var authReason;
 
     // Set auth reason


### PR DESCRIPTION
This informs [flow](https://flow.org/) that `authenticate` has a type of `(reason?: string) => *`