### PR TITLE
Bug fix: Returns error if authentication fails due to a fingerprint mismatch

### DIFF
--- a/TouchID.m
+++ b/TouchID.m
@@ -9,7 +9,7 @@ RCT_EXPORT_METHOD(isSupported: (RCTResponseSenderBlock)callback)
 {
     LAContext *context = [[LAContext alloc] init];
     NSError *error;
-    
+
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
         callback(@[[NSNull null], [self getBiometryType:context]]);
         // Device does not support TouchID
@@ -24,7 +24,7 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
 {
     LAContext *context = [[LAContext alloc] init];
     NSError *error;
-    
+
     // Device has TouchID
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
         // Attempt Authentification
@@ -32,53 +32,52 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
                 localizedReason:reason
                           reply:^(BOOL success, NSError *error)
          {
-             // Failed Authentication
-             if (error) {
+             if (success) { // Authentication Successful
+                 callback(@[[NSNull null], @"Authenticated with Touch ID."]);
+             } else if (error) { // Authentication Error
                  NSString *errorReason;
-                 
+
                  switch (error.code) {
                      case LAErrorAuthenticationFailed:
                          errorReason = @"LAErrorAuthenticationFailed";
                          break;
-                         
+
                      case LAErrorUserCancel:
                          errorReason = @"LAErrorUserCancel";
                          break;
-                         
+
                      case LAErrorUserFallback:
                          errorReason = @"LAErrorUserFallback";
                          break;
-                         
+
                      case LAErrorSystemCancel:
                          errorReason = @"LAErrorSystemCancel";
                          break;
-                         
+
                      case LAErrorPasscodeNotSet:
                          errorReason = @"LAErrorPasscodeNotSet";
                          break;
-                         
+
                      case LAErrorTouchIDNotAvailable:
                          errorReason = @"LAErrorTouchIDNotAvailable";
                          break;
-                         
+
                      case LAErrorTouchIDNotEnrolled:
                          errorReason = @"LAErrorTouchIDNotEnrolled";
                          break;
-                         
+
                      default:
                          errorReason = @"RCTTouchIDUnknownError";
                          break;
                  }
-                 
+
                  NSLog(@"Authentication failed: %@", errorReason);
                  callback(@[RCTMakeError(errorReason, nil, nil)]);
-                 return;
+             } else { // Authentication Failure
+                 callback(@[RCTMakeError(@"LAErrorAuthenticationFailed", nil, nil)]);
              }
-             
-             // Authenticated Successfully
-             callback(@[[NSNull null], @"Authenticat with Touch ID."]);
          }];
-        
+
         // Device does not support TouchID
     } else {
         callback(@[RCTMakeError(@"RCTTouchIDNotSupported", nil, nil)]);
@@ -91,7 +90,7 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
     if (@available(iOS 11, *)) {
         return context.biometryType == LABiometryTypeFaceID ? @"FaceID" : @"TouchID";
     }
-    
+
     return @"TouchID";
 }
 


### PR DESCRIPTION
This fixes a bug where a non-matching fingerprint scan also returned `true` rather than an error.