### PR TITLE
Add poddspec file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,26 @@ Due to the rapid changes being made in the React Native ecosystem, we are not of
 
 ## Usage
 ### Linking the Library
-In order to use Biometric Authentication, you must first link the library to your project.  There's excellent documentation on how to do this in the [React Native Docs](http://facebook.github.io/react-native/docs/linking-libraries-ios.html#content).
+In order to use Biometric Authentication, you must first link the library to your project.
 
-Or use the built-in command:
+#### Using react-native link
+Use the built-in command:
 ```shell
 react-native link react-native-touch-id
 ```
+
+#### Using Cocoapods (iOS only)
+On iOS you can also link package by updating your podfile
+```ruby
+pod 'TouchID', :path => "#{node_modules_path}/react-native-touch-id"
+```
+and then run
+```shell
+pod install
+```
+
+#### Using native linking
+There's excellent documentation on how to do this in the [React Native Docs](http://facebook.github.io/react-native/docs/linking-libraries-ios.html#content).
 
 ### Platform Differences
 

--- a/TouchID.podspec
+++ b/TouchID.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = "TouchID"
+  s.version      = "4.0.0"
+  s.summary      = "A React Native library for authenticating users with Touch ID"
+  s.homepage     = "https://github.com/naoufal/react-native-touch-id"
+  s.license      = "MIT"
+
+  s.author       = { "Naoufal Kadhom" => "naoufalkadhom@gmail.com" }
+  s.platform     = :ios, "7.0"
+  s.source       = { :git => "https://github.com/naoufal/react-native-touch-id.git" }
+
+  s.source_files  = "*.{h,m}"
+  s.dependency "React"
+end

--- a/TouchID.podspec
+++ b/TouchID.podspec
@@ -1,6 +1,10 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
 Pod::Spec.new do |s|
   s.name         = "TouchID"
-  s.version      = "4.0.0"
+  s.version      = package['version']
   s.summary      = "A React Native library for authenticating users with Touch ID"
   s.homepage     = "https://github.com/naoufal/react-native-touch-id"
   s.license      = "MIT"


### PR DESCRIPTION
Add podspec file. This will allow users to import this library as a Pod on iOS. 

CocoaPods - https://cocoapods.org/ - is a dependency manager for Swift and Objective-C Cocoa projects. It has over 42 thousand libraries and is used in over 3 million apps.

Podspec is a specification, that describes a version of Pod library. It includes details about where the source should be fetched from, what files to use, the build settings to apply, and other general metadata such as its name, version, and description.

This is a refresh of #31 with automatic version upgrade and update of readme file. 