### PR TITLE
Add support for optional display of fallback button on iOS

### DIFF
--- a/TouchID.ios.js
+++ b/TouchID.ios.js
@@ -25,7 +25,7 @@ export default {
     });
   },
 
-  authenticate(reason) {
+  authenticate(reason, displayFallback = true) {
     var authReason;
 
     // Set auth reason
@@ -37,7 +37,7 @@ export default {
     }
 
     return new Promise((resolve, reject) => {
-      NativeTouchID.authenticate(authReason, error => {
+      NativeTouchID.authenticate(authReason, displayFallback, error => {
         // Return error if rejected
         if (error) {
           return reject(createError(error.message));

--- a/TouchID.m
+++ b/TouchID.m
@@ -20,10 +20,16 @@ RCT_EXPORT_METHOD(isSupported: (RCTResponseSenderBlock)callback)
 }
 
 RCT_EXPORT_METHOD(authenticate: (NSString *)reason
+                  displayFallback: (BOOL)displayFallbackText
                   callback: (RCTResponseSenderBlock)callback)
 {
     LAContext *context = [[LAContext alloc] init];
     NSError *error;
+
+     if (!displayFallbackText) {
+       // Hide "Enter Password" fallback button
+       context.localizedFallbackTitle = @"";
+     }
 
     // Device has TouchID
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {


### PR DESCRIPTION
Refresh of #25 without conflicts.

This parameter enables to not show fallback button on iOS. The default is true, so no change is needed in the code.

Would it be better to have separate parameter for IOS like this or create a config object for IOS as well and have displayFallback as key and value there? (to be compatible with the android parameter)