### PR TITLE
Allow to hide or change text on fallback button on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,16 @@ Returns a `Promise` object.
 __Arguments__
 - `reason` - An _optional_ `String` that provides a clear reason for requesting authentication.
 
-- `config` - **optional - Android only** (does nothing on iOS) - an object that specifies the title and color to present in the confirmation dialog.
+- `config` - _optional_ an object that specifies the title and color to present in the confirmation dialog (on Android) 
+or text/visibility of 'Show Password' label when touch id authentication failed.
 
 __Examples__
 ```js
 //config is optional to be passed in on Android
 const optionalConfigObject = {
-  title: "Authentication Required",
-  color: "#e00606"
+  title: "Authentication Required", // Android
+  color: "#e00606", // Android,
+  failbackLabel: "Show Passcode" // iOS (if empty, then label is hidden)
 }
 
 TouchID.authenticate('to demo this react-native component', optionalConfigObject)

--- a/README.md
+++ b/README.md
@@ -109,10 +109,13 @@ Attempts to authenticate with Face ID/Touch ID.
 Returns a `Promise` object.
 
 __Arguments__
-- `reason` - An _optional_ `String` that provides a clear reason for requesting authentication.
+- `reason` - **optional** - `String` that provides a clear reason for requesting authentication.
 
-- `config` - An _optional_ `Object` that specifies the title and color to present in the confirmation dialog (on Android) 
-or text/visibility of 'Show Password' label when touch id authentication failed.
+- `config` - **optional** - configuration object for more detailed dialog setup:
+  - `title` - **Android** - title of confirmation dialog
+  - `color` - **Android** - color of confirmation dialog
+  - `failbackLabel` - **iOS** - by default specified 'Show Password' label. If set to empty string label is invisible.
+
 
 __Examples__
 ```js

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Returns a `Promise` object.
 __Arguments__
 - `reason` - An _optional_ `String` that provides a clear reason for requesting authentication.
 
-- `config` - _optional_ an object that specifies the title and color to present in the confirmation dialog (on Android) 
+- `config` - An _optional_ `Object` that specifies the title and color to present in the confirmation dialog (on Android) 
 or text/visibility of 'Show Password' label when touch id authentication failed.
 
 __Examples__

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ __Arguments__
 - `config` - **optional** - configuration object for more detailed dialog setup:
   - `title` - **Android** - title of confirmation dialog
   - `color` - **Android** - color of confirmation dialog
-  - `failbackLabel` - **iOS** - by default specified 'Show Password' label. If set to empty string label is invisible.
+  - `fallbackLabel` - **iOS** - by default specified 'Show Password' label. If set to empty string label is invisible.
 
 
 __Examples__

--- a/TouchID.ios.js
+++ b/TouchID.ios.js
@@ -25,19 +25,13 @@ export default {
     });
   },
 
-  authenticate(reason) {
-    var authReason;
-
-    // Set auth reason
-    if (reason) {
-      authReason = reason;
-    // Set as empty string if no reason is passed
-    } else {
-      authReason = ' ';
-    }
+  authenticate(reason, config) {
+    const DEFAULT_CONFIG = { fallbackLabel: null };
+    const authReason = reason ? reason : ' ';
+    const authConfig = config ? config : DEFAULT_CONFIG;
 
     return new Promise((resolve, reject) => {
-      NativeTouchID.authenticate(authReason, error => {
+      NativeTouchID.authenticate(authReason, authConfig, error => {
         // Return error if rejected
         if (error) {
           return reject(createError(error.message));

--- a/TouchID.m
+++ b/TouchID.m
@@ -10,7 +10,7 @@ RCT_EXPORT_METHOD(isSupported: (RCTResponseSenderBlock)callback)
 {
     LAContext *context = [[LAContext alloc] init];
     NSError *error;
-    
+
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
         callback(@[[NSNull null], [self getBiometryType:context]]);
         // Device does not support TouchID
@@ -43,36 +43,36 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
                  callback(@[[NSNull null], @"Authenticated with Touch ID."]);
              } else if (error) { // Authentication Error
                  NSString *errorReason;
-                 
+
                  switch (error.code) {
                      case LAErrorAuthenticationFailed:
                          errorReason = @"LAErrorAuthenticationFailed";
                          break;
-                         
+
                      case LAErrorUserCancel:
                          errorReason = @"LAErrorUserCancel";
                          break;
-                         
+
                      case LAErrorUserFallback:
                          errorReason = @"LAErrorUserFallback";
                          break;
-                         
+
                      case LAErrorSystemCancel:
                          errorReason = @"LAErrorSystemCancel";
                          break;
-                         
+
                      case LAErrorPasscodeNotSet:
                          errorReason = @"LAErrorPasscodeNotSet";
                          break;
-                         
+
                      case LAErrorTouchIDNotAvailable:
                          errorReason = @"LAErrorTouchIDNotAvailable";
                          break;
-                         
+
                      case LAErrorTouchIDNotEnrolled:
                          errorReason = @"LAErrorTouchIDNotEnrolled";
                          break;
-                         
+
                      default:
                          errorReason = @"RCTTouchIDUnknownError";
                          break;

--- a/TouchID.m
+++ b/TouchID.m
@@ -27,7 +27,7 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
     LAContext *context = [[LAContext alloc] init];
     NSError *error;
 
-    if ([options objectForKey:@"fallbackLabel"] != nil) {
+    if (RCTNilIfNull([options objectForKey:@"fallbackLabel"]) != nil) {
         NSString *fallbackLabel = [RCTConvert NSString:options[@"fallbackLabel"]];   
         context.localizedFallbackTitle = fallbackLabel;
     }

--- a/TouchID.m
+++ b/TouchID.m
@@ -1,5 +1,6 @@
 #import "TouchID.h"
 #import <React/RCTUtils.h>
+#import "React/RCTConvert.h"
 
 @implementation TouchID
 
@@ -9,7 +10,7 @@ RCT_EXPORT_METHOD(isSupported: (RCTResponseSenderBlock)callback)
 {
     LAContext *context = [[LAContext alloc] init];
     NSError *error;
-
+    
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
         callback(@[[NSNull null], [self getBiometryType:context]]);
         // Device does not support TouchID
@@ -20,10 +21,16 @@ RCT_EXPORT_METHOD(isSupported: (RCTResponseSenderBlock)callback)
 }
 
 RCT_EXPORT_METHOD(authenticate: (NSString *)reason
+                  options:(NSDictionary *)options
                   callback: (RCTResponseSenderBlock)callback)
 {
     LAContext *context = [[LAContext alloc] init];
     NSError *error;
+
+    if ([options objectForKey:@"fallbackLabel"] != nil) {
+        NSString *fallbackLabel = [RCTConvert NSString:options[@"fallbackLabel"]];   
+        context.localizedFallbackTitle = fallbackLabel;
+    }
 
     // Device has TouchID
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
@@ -36,36 +43,36 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
                  callback(@[[NSNull null], @"Authenticated with Touch ID."]);
              } else if (error) { // Authentication Error
                  NSString *errorReason;
-
+                 
                  switch (error.code) {
                      case LAErrorAuthenticationFailed:
                          errorReason = @"LAErrorAuthenticationFailed";
                          break;
-
+                         
                      case LAErrorUserCancel:
                          errorReason = @"LAErrorUserCancel";
                          break;
-
+                         
                      case LAErrorUserFallback:
                          errorReason = @"LAErrorUserFallback";
                          break;
-
+                         
                      case LAErrorSystemCancel:
                          errorReason = @"LAErrorSystemCancel";
                          break;
-
+                         
                      case LAErrorPasscodeNotSet:
                          errorReason = @"LAErrorPasscodeNotSet";
                          break;
-
+                         
                      case LAErrorTouchIDNotAvailable:
                          errorReason = @"LAErrorTouchIDNotAvailable";
                          break;
-
+                         
                      case LAErrorTouchIDNotEnrolled:
                          errorReason = @"LAErrorTouchIDNotEnrolled";
                          break;
-
+                         
                      default:
                          errorReason = @"RCTTouchIDUnknownError";
                          break;
@@ -95,4 +102,5 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
 }
 
 @end
+
 


### PR DESCRIPTION
This is extended version of #73.
With this change it is possible to set custom text for `Enter Password` button or to hide it (for iOS).
It is backward compatible - for current users all functionality will work same, until they set `fallbackLabel` option.

Also I've updated documentation with new option.