### PR TITLE
Fix android error from reusing a callback

### DIFF
--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -122,10 +122,6 @@ public class FingerprintDialog extends DialogFragment
 
     @Override
     public void onError(String errorString) {
-        if (errorString == "Authentication Failed") {
-            return;
-        }
-
         dialogCallback.onError(errorString);
         dismiss();
     }

--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -33,7 +33,7 @@ public class FingerprintDialog extends DialogFragment
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);        
+        super.onCreate(savedInstanceState);
         setStyle(DialogFragment.STYLE_NORMAL, android.R.style.Theme_Material_Light_Dialog);
     }
 
@@ -122,6 +122,10 @@ public class FingerprintDialog extends DialogFragment
 
     @Override
     public void onError(String errorString) {
+        if (errorString == "Authentication Failed") {
+            return;
+        }
+
         dialogCallback.onError(errorString);
         dismiss();
     }

--- a/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
@@ -57,11 +57,6 @@ public class FingerprintHandler extends FingerprintManager.AuthenticationCallbac
     }
 
     @Override
-    public void onAuthenticationFailed() {
-        mCallback.onError("Authentication Failed");
-    }
-
-    @Override
     public void onAuthenticationSucceeded(FingerprintManager.AuthenticationResult result) {
         mCallback.onAuthenticated();
     }


### PR DESCRIPTION
The dialog closes on android after an incorrect attempt to authenticate, but the app keeps listening for fingerprints and breaks.

I think we just want to leave the dialog open if the error is "Authentication Failed" (fingerprint wasn't recognized). Then when the error is "Too many attempts. Try again later." the dialog closes.

This seems to work fine, but in `FingerprintHandler.java` the `endAuth` method also calls the `onError` callback with "Authentication Failed" if the `cancellationSignal` has already been cancelled for some reason. I guess that's unlikely, but maybe that error message should be changed to avoid issues?

fixes #67