### PR TITLE
Fix IOS 11.0.0 crashing on set context.biometryType

### DIFF
--- a/TouchID.m
+++ b/TouchID.m
@@ -87,7 +87,7 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
 
 - (NSString *)getBiometryType:(LAContext *)context
 {
-    if (@available(iOS 11, *)) {
+    if (@available(iOS 11.0.1, *)) {
         return (context.biometryType == LABiometryTypeFaceID) ? @"FaceID" : @"TouchID";
     }
 


### PR DESCRIPTION
Fix crash in accordance with https://stackoverflow.com/questions/46231683/how-to-access-faceid-for-new-iphone-x#comment82325560_46231721