### PR TITLE
Call cancellation handler in each fingerpringmanager callback method

### DIFF
--- a/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
@@ -37,13 +37,12 @@ public class FingerprintHandler extends FingerprintManager.AuthenticationCallbac
     }
 
     public void endAuth() {
-        if (cancellationSignal != null) {
-            cancellationSignal.cancel();
-            cancellationSignal = null;
+        if (!selfCancelled) {
             selfCancelled = true;
         } else {
           mCallback.onError("Authentication Failed");
         }
+        cancellationSignal.cancel();
     }
 
     @Override
@@ -54,16 +53,19 @@ public class FingerprintHandler extends FingerprintManager.AuthenticationCallbac
         } else {
             mCallback.onCancelled();
         }
+        cancellationSignal.cancel();
     }
 
     @Override
     public void onAuthenticationFailed() {
         mCallback.onError("Authentication Failed");
+        cancellationSignal.cancel();
     }
 
     @Override
     public void onAuthenticationSucceeded(FingerprintManager.AuthenticationResult result) {
         mCallback.onAuthenticated();
+        cancellationSignal.cancel();
     }
 
     public interface Callback {


### PR DESCRIPTION
Not calling cancellation signal in some cases leads to android to releasing the fingerprint manager properly, which on the other hand causes the fingerprint to fail immediately on a subsequent attempt. See this SO question for more details: https://stackoverflow.com/questions/45136354/fingerprint-operation-cancelled-while-using-in-app-authentication