### PR TITLE
Fix crashes on some Samsung devices

### DIFF
--- a/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
@@ -121,6 +121,10 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule {
       if (!keyguardManager.isKeyguardSecure()) {
           return false;
       }
+    
+      if (!fingerprintManager.isHardwareDetected()) {
+          return false; 
+      }
 
       if (!fingerprintManager.hasEnrolledFingerprints()) {
           return false;


### PR DESCRIPTION
Adds additional fix which prevents crashes on some Samsung devices (Galaxy A3 in my case). Error is apparently caused by some firmware issue. Some more info:
- https://stackoverflow.com/questions/39372230/fingerprintmanagercompat-method-had-issues-with-samsung-devices
-  https://stackoverflow.com/questions/47221300/fingerprint-crash-on-specific-samsung-devices