### PR TITLE
[Android] Crash when empty object passed into authentication config parameter

### DIFF
--- a/TouchID.android.js
+++ b/TouchID.android.js
@@ -19,7 +19,7 @@ export default {
   authenticate(reason, config) {
     DEFAULT_CONFIG = { title: 'Authentication Required', color: '#1306ff' };
     var authReason = reason ? reason : ' ';
-    var authConfig = config ? config : DEFAULT_CONFIG;
+    var authConfig = Object.assign({}, DEFAULT_CONFIG, config);
     var color = processColor(authConfig.color);
 
     authConfig.color = color;


### PR DESCRIPTION
Fix for #98 

If you pass an empty object into the `authenticate` method the defaults will not be used leaving title and color blank. 

**Bug replication**
```javascript
TouchID.authenticate('Login', {})
  .then(success => {
    // Success code
  })
  .catch(error => {
    // Failure code
  });
```

Which causes the following lines to crash the application: 
**FingerprintDialog.java**
```java
        getDialog().setTitle(authConfig.getString("title"));
        int color = authConfig.getInt("color");
```

A more robust fix would add defensive checks here but I'm not familiar with Java. 

**Solution**
Use `Object.assign` to merge the default config and the config object meaning that `title` and `color` will always have a default value, therefore preventing the crash. 