### PR TITLE
`auth` API parameters with localized strings

### DIFF
--- a/TouchID.android.js
+++ b/TouchID.android.js
@@ -16,8 +16,8 @@ export default {
     });
   },
 
-  authenticate(reason, config) {
-    DEFAULT_CONFIG = { title: 'Authentication Required', color: '#1306ff' };
+  authenticate(reason, title = 'Authentication Required', touchText = 'Touch Sensor', cancelText= 'Cancel', config) {
+    DEFAULT_CONFIG = { title, color: '#1306ff' };
     var authReason = reason ? reason : ' ';
     var authConfig = Object.assign({}, DEFAULT_CONFIG, config);
     var color = processColor(authConfig.color);
@@ -27,6 +27,8 @@ export default {
     return new Promise((resolve, reject) => {
       NativeTouchID.authenticate(
         authReason,
+        touchText,
+        cancelText,
         authConfig,
         error => {
           return reject(typeof error == 'String' ? createError(error, error) : createError(error));

--- a/TouchID.android.js
+++ b/TouchID.android.js
@@ -16,7 +16,7 @@ export default {
     });
   },
 
-  authenticate(reason, cancelText= 'Cancel', title = 'Authentication Required', touchText = 'Touch Sensor', config) {
+  authenticate(reason, cancelText = 'Cancel', title = 'Authentication Required', touchText = 'Touch Sensor', config) {
     DEFAULT_CONFIG = { title, color: '#1306ff' };
     var authReason = reason ? reason : ' ';
     var authConfig = Object.assign({}, DEFAULT_CONFIG, config);

--- a/TouchID.android.js
+++ b/TouchID.android.js
@@ -16,7 +16,7 @@ export default {
     });
   },
 
-  authenticate(reason, title = 'Authentication Required', touchText = 'Touch Sensor', cancelText= 'Cancel', config) {
+  authenticate(reason, cancelText= 'Cancel', title = 'Authentication Required', touchText = 'Touch Sensor', config) {
     DEFAULT_CONFIG = { title, color: '#1306ff' };
     var authReason = reason ? reason : ' ';
     var authConfig = Object.assign({}, DEFAULT_CONFIG, config);

--- a/TouchID.ios.js
+++ b/TouchID.ios.js
@@ -25,7 +25,7 @@ export default {
     });
   },
 
-  authenticate(reason, cancelText= 'Cancel') {
+  authenticate(reason, cancelText = 'Cancel') {
     var authReason;
 
     // Set auth reason

--- a/TouchID.ios.js
+++ b/TouchID.ios.js
@@ -25,7 +25,7 @@ export default {
     });
   },
 
-  authenticate(reason) {
+  authenticate(reason, cancelText= 'Cancel') {
     var authReason;
 
     // Set auth reason
@@ -37,7 +37,7 @@ export default {
     }
 
     return new Promise((resolve, reject) => {
-      NativeTouchID.authenticate(authReason, error => {
+      NativeTouchID.authenticate(authReason, cancelText, error => {
         // Return error if rejected
         if (error) {
           return reject(createError(error.message));

--- a/TouchID.m
+++ b/TouchID.m
@@ -20,9 +20,12 @@ RCT_EXPORT_METHOD(isSupported: (RCTResponseSenderBlock)callback)
 }
 
 RCT_EXPORT_METHOD(authenticate: (NSString *)reason
+                  cancelText: (NSString *)cancelText
                   callback: (RCTResponseSenderBlock)callback)
 {
     LAContext *context = [[LAContext alloc] init];
+    context.localizedFallbackTitle = @"";
+    context.localizedCancelTitle = cancelText;
     NSError *error;
 
     // Device has TouchID

--- a/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
@@ -64,7 +64,7 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void authenticate(String reason, ReadableMap authConfig, Callback reactErrorCallback, Callback reactSuccessCallback) {
+  public void authenticate(String reason, String touchText, String cancelText, ReadableMap authConfig, Callback reactErrorCallback, Callback reactSuccessCallback) {
     if (!inProgress) {
       inProgress = true;
       keyguardManager =
@@ -84,6 +84,8 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule {
           DialogResultHandler drh = new DialogResultHandler(reactErrorCallback, reactSuccessCallback);
 
           fingerprintDialog.setReasonForAuthentication(reason);
+          fingerprintDialog.setTouchSensorText(touchText);
+          fingerprintDialog.setCancelText(cancelText);
           fingerprintDialog.setAuthConfig(authConfig);
           fingerprintDialog.setDialogCallback(drh);
 

--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -22,6 +22,7 @@ public class FingerprintDialog extends DialogFragment
     private Button mCancelButton;
     private View mFingerprintContent;
     private TextView mFingerprintDescription;
+    private TextView mTouchSensorDescription;
     private ImageView mFingerprintImage;
 
     private FingerprintManager.CryptoObject mCryptoObject;
@@ -29,11 +30,13 @@ public class FingerprintDialog extends DialogFragment
     private FingerprintHandler mFingerprintHandler;
 
     private String authReason;
+    private String touchSensorText;
+    private String cancelText;
     private ReadableMap authConfig;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);        
+        super.onCreate(savedInstanceState);
         setStyle(DialogFragment.STYLE_NORMAL, android.R.style.Theme_Material_Light_Dialog);
     }
 
@@ -50,12 +53,13 @@ public class FingerprintDialog extends DialogFragment
         View v = inflater.inflate(R.layout.fingerprint_dialog, container, false);
 
         mFingerprintContent = v.findViewById(R.id.fingerprint_container);
-
         mFingerprintDescription = (TextView) v.findViewById(R.id.fingerprint_description);
-
         mFingerprintDescription.setText(authReason);
-        mFingerprintImage = (ImageView) v.findViewById(R.id.fingerprint_icon);
 
+        mTouchSensorDescription = (TextView) v.findViewById(R.id.touchsensor_description);
+        mTouchSensorDescription.setText(touchSensorText);
+
+        mFingerprintImage = (ImageView) v.findViewById(R.id.fingerprint_icon);
         mFingerprintImage.setColorFilter(color);
 
         mFingerprintHandler = new FingerprintHandler(this.getContext(), this.getActivity().getSystemService(FingerprintManager.class), this);
@@ -69,6 +73,7 @@ public class FingerprintDialog extends DialogFragment
 
         mCancelButton = (Button) v.findViewById(R.id.cancel_button);
         mCancelButton.setTextColor(color);
+        mCancelButton.setText(cancelText);
         mCancelButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -102,6 +107,14 @@ public class FingerprintDialog extends DialogFragment
 
     public void setReasonForAuthentication(String reason) {
       authReason = reason;
+    }
+
+    public void setTouchSensorText(String label) {
+      touchSensorText = label;
+    }
+
+    public void setCancelText(String label) {
+      cancelText = label;
     }
 
     public void setAuthConfig(ReadableMap config) {

--- a/android/src/main/res/layout/fingerprint_dialog.xml
+++ b/android/src/main/res/layout/fingerprint_dialog.xml
@@ -41,6 +41,7 @@
             android:src="@drawable/ic_fp_40px" />
 
         <TextView
+            android:id="@+id/touchsensor_description"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_marginLeft="15dp"
@@ -59,6 +60,7 @@
         android:layout_gravity="bottom|right"
         android:background="#fff"
         android:text="Cancel"
+        android:layout_marginBottom="30dp"
         android:textColor="#000" />
 
 </LinearLayout>


### PR DESCRIPTION
Included the `cancel` button texts (for both iOS and Android), and Finger print dialog texts ( Android only), so that clients can pass the localized strings.