### PR TITLE
Adds readme section on permissions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ On Android you can customize the title and color of the pop-up by passing in the
 
 Error handling is also different between the platforms, with iOS currently providing much more descriptive error codes.
 
+### App Permissions
+
+Add the following permissions to their respective files:
+
+In your `AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.USE_FINGERPRINT" />
+```
+
+In your `Info.plist`:
+
+```xml
+<key>NSFaceIDUsageDescription</key>
+<string>Enabling Face ID allows you quick and secure access to your account.</string>
+```
+
 ### Requesting Face ID/Touch ID Authentication
 Once you've linked the library, you'll want to make it available to your app by requiring it:
 


### PR DESCRIPTION
It may not be needed in the `AndroidManifest.xml` file but if you want FaceID to work without an [ominous warning on the iPhone X](https://betterment.engineering/supporting-face-id-on-the-iphone-x-3314ffcf0982), you *must* add the `NSFaceIDUsageDescription` key to the `Info.plist` file.