### PR TITLE
Fixed. On iOS some times ERRORS[error] is not set,

### DIFF
--- a/TouchID.ios.js
+++ b/TouchID.ios.js
@@ -59,7 +59,7 @@ TouchIDError.prototype = Object.create(Error.prototype);
 TouchIDError.prototype.constructor = TouchIDError;
 
 function createError(error) {
-  let details = ERRORS[error];
+  let details = {...ERRORS[error]};
   details.name = error;
 
   return new TouchIDError(error, details);


### PR DESCRIPTION
Fixed. On iOS some times ERRORS[error] is not set,
so the details.name = error; throws an error.