### PR TITLE
Bugfix/issue 106

### DIFF
--- a/android/src/main/java/com/rnfingerprint/DialogResultHandler.java
+++ b/android/src/main/java/com/rnfingerprint/DialogResultHandler.java
@@ -2,8 +2,6 @@ package com.rnfingerprint;
 
 import com.facebook.react.bridge.Callback;
 
-import android.util.Log;
-
 public class DialogResultHandler implements FingerprintDialog.DialogResultListener {
     private Callback errorCallback;
     private Callback successCallback;

--- a/android/src/main/java/com/rnfingerprint/DialogResultHandler.java
+++ b/android/src/main/java/com/rnfingerprint/DialogResultHandler.java
@@ -11,7 +11,7 @@ public class DialogResultHandler implements FingerprintDialog.DialogResultListen
     public DialogResultHandler(Callback reactErrorCallback, Callback reactSuccessCallback) {
       errorCallback = reactErrorCallback;
       successCallback = reactSuccessCallback;
-    };
+    }
 
     @Override
     public void onAuthenticated() {

--- a/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
@@ -1,198 +1,175 @@
 package com.rnfingerprint;
 
-import com.facebook.react.bridge.NativeModule;
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.app.KeyguardManager;
+import android.content.Context;
+import android.hardware.fingerprint.FingerprintManager;
+import android.os.Build;
+
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReadableMap;
 
-import android.os.Bundle;
-import android.app.Activity;
-import android.content.Context;
-import android.app.KeyguardManager;
-import android.hardware.fingerprint.FingerprintManager;
-import android.Manifest;
-import android.content.pm.PackageManager;
-import android.support.v4.app.ActivityCompat;
-import android.security.keystore.KeyProperties;
-import android.security.keystore.KeyGenParameterSpec;
-import android.security.keystore.KeyPermanentlyInvalidatedException;
-import android.util.Log;
-
-import java.security.KeyStore;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.cert.CertificateException;
-import java.security.InvalidAlgorithmParameterException;
-import java.io.IOException;
-import javax.crypto.KeyGenerator;
 import javax.crypto.Cipher;
-import javax.crypto.NoSuchPaddingException;
-import javax.crypto.SecretKey;
-import java.security.InvalidKeyException;
-import java.security.KeyStoreException;
-import java.security.UnrecoverableKeyException;
 
+public class FingerprintAuthModule extends ReactContextBaseJavaModule implements LifecycleEventListener {
 
-public class FingerprintAuthModule extends ReactContextBaseJavaModule {
+    private static final String FRAGMENT_TAG = "fingerprint_dialog";
 
-  public static boolean inProgress = false;
+    private Cipher cipher;
+    private FingerprintManager fingerprintManager;
+    private KeyguardManager keyguardManager;
+    private boolean isAppActive;
 
-  public FingerprintAuthModule(ReactApplicationContext reactContext) {
-    super(reactContext);
-  }
+    public static boolean inProgress = false;
 
-  @Override
-  public String getName() {
-    return "FingerprintAuth";
-  }
+    public FingerprintAuthModule(final ReactApplicationContext reactContext) {
+        super(reactContext);
 
-  @ReactMethod
-  public void isSupported(Callback reactErrorCallback, Callback reactSuccessCallback) {
-    keyguardManager =
-            (KeyguardManager) getCurrentActivity().getSystemService(Context.KEYGUARD_SERVICE);
-    fingerprintManager =
-            (FingerprintManager) getCurrentActivity().getSystemService(Context.FINGERPRINT_SERVICE);
-    if(!isFingerprintAuthAvailable()) {
-      reactErrorCallback.invoke("Not supported.");
-    } else {
-      reactSuccessCallback.invoke("Is supported.");
+        reactContext.addLifecycleEventListener(this);
     }
-    return ;
-  }
 
-  @ReactMethod
-  public void authenticate(String reason, ReadableMap authConfig, Callback reactErrorCallback, Callback reactSuccessCallback) {
-    if (!inProgress) {
-      inProgress = true;
-      keyguardManager =
-      (KeyguardManager) getCurrentActivity().getSystemService(Context.KEYGUARD_SERVICE);
-      fingerprintManager =
-      (FingerprintManager) getCurrentActivity().getSystemService(Context.FINGERPRINT_SERVICE);
-
-      Activity activity = getCurrentActivity();
-
-      if (isFingerprintAuthAvailable()) {
-        generateKey();
-        if (cipherInit()) {
-          cryptoObject = new FingerprintManager.CryptoObject(cipher);
-          fingerprintDialog = new FingerprintDialog();
-          fingerprintDialog.setCryptoObject(cryptoObject);
-
-          DialogResultHandler drh = new DialogResultHandler(reactErrorCallback, reactSuccessCallback);
-
-          fingerprintDialog.setReasonForAuthentication(reason);
-          fingerprintDialog.setAuthConfig(authConfig);
-          fingerprintDialog.setDialogCallback(drh);
-
-          fingerprintDialog.show(activity.getFragmentManager(),"fingerprint_dialog");
+    private Cipher getCipher() {
+        if (cipher != null) {
+            return cipher;
         }
-      }
 
-      return;
+        cipher = new FingerprintCipher().getCipher();
 
+        return cipher;
     }
-  }
 
-  /*** TOUCH ID ACTIVITY RELATED STUFF ***/
-  private FingerprintDialog fingerprintDialog;
+    @TargetApi(Build.VERSION_CODES.M)
+    private FingerprintManager getFingerprintManager() {
+        if (fingerprintManager != null) {
+            return fingerprintManager;
+        }
 
-  private FingerprintManager fingerprintManager;
-  private KeyguardManager keyguardManager;
+        final Activity activity = getCurrentActivity();
+        if (activity == null) {
+            return null;
+        }
+        fingerprintManager = (FingerprintManager) activity.getSystemService(Context.FINGERPRINT_SERVICE);
 
-  private KeyStore keyStore;
-  private KeyGenerator keyGenerator;
+        return fingerprintManager;
+    }
 
-  private Cipher cipher;
-  private static final String KEY_NAME = "example_key";
+    @TargetApi(Build.VERSION_CODES.M)
+    private KeyguardManager getKeyguardManager() {
+        if (keyguardManager != null) {
+            return keyguardManager;
+        }
+        final Activity activity = getCurrentActivity();
+        if (activity == null) {
+            return null;
+        }
 
-  private FingerprintManager.CryptoObject cryptoObject;
+        keyguardManager = (KeyguardManager) activity.getSystemService(Context.KEYGUARD_SERVICE);
 
-  private Context appContext;
+        return keyguardManager;
+    }
 
-  public boolean isFingerprintAuthAvailable() {
+    @Override
+    public String getName() {
+        return "FingerprintAuth";
+    }
 
-      if (android.os.Build.VERSION.SDK_INT < 23) {
-          return false;
-      }
+    @TargetApi(Build.VERSION_CODES.M)
+    @ReactMethod
+    public void isSupported(final Callback reactErrorCallback, final Callback reactSuccessCallback) {
+        final Activity activity = getCurrentActivity();
+        if (activity == null) {
+            return;
+        }
 
-      if (!keyguardManager.isKeyguardSecure()) {
-          return false;
-      }
+        if (!isFingerprintAuthAvailable()) {
+            reactErrorCallback.invoke("Not supported.");
+        } else {
+            reactSuccessCallback.invoke("Is supported.");
+        }
+    }
 
-      if (!fingerprintManager.isHardwareDetected()) {
-          return false;
-      }
+    @TargetApi(Build.VERSION_CODES.M)
+    @ReactMethod
+    public void authenticate(final String reason, final ReadableMap authConfig, final Callback reactErrorCallback, final Callback reactSuccessCallback) {
+        if (inProgress || !isAppActive) {
+            return;
+        }
+        final Activity activity = getCurrentActivity();
+        if (activity == null) {
+            return;
+        }
 
-      if (!fingerprintManager.hasEnrolledFingerprints()) {
-          return false;
-      }
+        inProgress = true;
 
-      return true;
-  }
+        if (!isFingerprintAuthAvailable()) {
+            inProgress = false;
+            reactErrorCallback.invoke("Not supported");
+            return;
+        }
 
-  protected void generateKey() {
-      try {
-          keyStore = KeyStore.getInstance("AndroidKeyStore");
-      } catch (Exception e) {
-          e.printStackTrace();
-      }
+        final Cipher cipher = this.getCipher();
+        if (cipher == null) {
+            inProgress = false;
+            reactErrorCallback.invoke("Not supported");
+            return;
+        }
 
-      try {
-          keyGenerator = KeyGenerator.getInstance(
-                  KeyProperties.KEY_ALGORITHM_AES,
-                  "AndroidKeyStore");
-      } catch (NoSuchAlgorithmException |
-              NoSuchProviderException e) {
-          throw new RuntimeException(
-                  "Failed to get KeyGenerator instance", e);
-      }
+        final FingerprintManager.CryptoObject cryptoObject = new FingerprintManager.CryptoObject(cipher);
 
-      try {
-          keyStore.load(null);
-          keyGenerator.init(new
-                  KeyGenParameterSpec.Builder(KEY_NAME,
-                  KeyProperties.PURPOSE_ENCRYPT |
-                          KeyProperties.PURPOSE_DECRYPT)
-                  .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
-                  .setUserAuthenticationRequired(true)
-                  .setEncryptionPaddings(
-                          KeyProperties.ENCRYPTION_PADDING_PKCS7)
-                  .build());
-          keyGenerator.generateKey();
-      } catch (NoSuchAlgorithmException |
-              InvalidAlgorithmParameterException |
-              CertificateException | IOException e) {
-          throw new RuntimeException(e);
-      }
-  }
+        /* TOUCH ID ACTIVITY RELATED STUFF */
+        final FingerprintDialog fingerprintDialog = new FingerprintDialog();
+        fingerprintDialog.setCryptoObject(cryptoObject);
 
-  public boolean cipherInit() {
-      try {
-          cipher = Cipher.getInstance(
-                  KeyProperties.KEY_ALGORITHM_AES + "/"
-                          + KeyProperties.BLOCK_MODE_CBC + "/"
-                          + KeyProperties.ENCRYPTION_PADDING_PKCS7);
-      } catch (NoSuchAlgorithmException |
-              NoSuchPaddingException e) {
-          throw new RuntimeException("Failed to get Cipher", e);
-      }
+        final DialogResultHandler drh = new DialogResultHandler(reactErrorCallback, reactSuccessCallback);
 
-      try {
-          keyStore.load(null);
-          SecretKey key = (SecretKey) keyStore.getKey(KEY_NAME,
-                  null);
-          cipher.init(Cipher.ENCRYPT_MODE, key);
-          return true;
-      } catch (InvalidKeyException e) {
-          return false;
-      } catch (KeyStoreException | CertificateException
-              | UnrecoverableKeyException | IOException
-              | NoSuchAlgorithmException e) {
-          throw new RuntimeException("Failed to init Cipher", e);
-      }
-  }
+        fingerprintDialog.setReasonForAuthentication(reason);
+        fingerprintDialog.setAuthConfig(authConfig);
+        fingerprintDialog.setDialogCallback(drh);
 
+        if (!isAppActive) {
+            inProgress = false;
+            return;
+        }
+
+        fingerprintDialog.show(activity.getFragmentManager(), FRAGMENT_TAG);
+    }
+
+    private boolean isFingerprintAuthAvailable() {
+        if (android.os.Build.VERSION.SDK_INT < 23) {
+            return false;
+        }
+
+        final KeyguardManager keyguardManager = getKeyguardManager();
+        final FingerprintManager fingerprintManager = getFingerprintManager();
+
+        if (keyguardManager == null || !keyguardManager.isKeyguardSecure()) {
+            return false;
+        }
+
+        if (fingerprintManager == null || !fingerprintManager.isHardwareDetected()) {
+            return false;
+        }
+
+        return fingerprintManager.hasEnrolledFingerprints();
+    }
+
+    @Override
+    public void onHostResume() {
+        isAppActive = true;
+    }
+
+    @Override
+    public void onHostPause() {
+        isAppActive = false;
+    }
+
+    @Override
+    public void onHostDestroy() {
+        isAppActive = false;
+    }
 }

--- a/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
@@ -121,7 +121,7 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule implements
 
         final FingerprintManager.CryptoObject cryptoObject = new FingerprintManager.CryptoObject(cipher);
 
-        /* TOUCH ID ACTIVITY RELATED STUFF */
+        /* FINGERPRINT ACTIVITY RELATED STUFF */
         final FingerprintDialog fingerprintDialog = new FingerprintDialog();
         fingerprintDialog.setCryptoObject(cryptoObject);
 

--- a/android/src/main/java/com/rnfingerprint/FingerprintCipher.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintCipher.java
@@ -1,0 +1,60 @@
+package com.rnfingerprint;
+
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+
+import java.security.KeyStore;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+
+/**
+ * Created by Nikolay Demyankov on 24.05.18.
+ */
+public class FingerprintCipher {
+
+    private static final String KEY_NAME = "example_key";
+
+    private Cipher cipher;
+
+    @TargetApi(Build.VERSION_CODES.M)
+    public Cipher getCipher() {
+        if (cipher != null) {
+            return cipher;
+        }
+
+        try {
+            final KeyStore keyStore = generateKey();
+            final String algo = KeyProperties.KEY_ALGORITHM_AES + "/" + KeyProperties.BLOCK_MODE_CBC + "/" + KeyProperties.ENCRYPTION_PADDING_PKCS7;
+            cipher = Cipher.getInstance(algo);
+
+            keyStore.load(null);
+            SecretKey key = (SecretKey) keyStore.getKey(KEY_NAME, null);
+            cipher.init(Cipher.ENCRYPT_MODE, key);
+        } catch (Exception e) {
+            // ignored
+        }
+
+        return cipher;
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    private KeyStore generateKey() throws Exception {
+        final KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+        final KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore");
+
+        keyStore.load(null);
+        keyGenerator.init(new KeyGenParameterSpec.Builder(
+                KEY_NAME, KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
+                .setUserAuthenticationRequired(true)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
+                .build());
+        keyGenerator.generateKey();
+
+        return keyStore;
+    }
+}

--- a/android/src/main/java/com/rnfingerprint/FingerprintCipher.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintCipher.java
@@ -12,15 +12,16 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 
 /**
- * Created by Nikolay Demyankov on 24.05.18.
+ * Helper to create a Cipher.
  */
+@TargetApi(Build.VERSION_CODES.M)
 public class FingerprintCipher {
 
     private static final String KEY_NAME = "example_key";
+    private static final String CIPHER_ALGO = KeyProperties.KEY_ALGORITHM_AES + "/" + KeyProperties.BLOCK_MODE_CBC + "/" + KeyProperties.ENCRYPTION_PADDING_PKCS7;
 
     private Cipher cipher;
 
-    @TargetApi(Build.VERSION_CODES.M)
     public Cipher getCipher() {
         if (cipher != null) {
             return cipher;
@@ -28,20 +29,17 @@ public class FingerprintCipher {
 
         try {
             final KeyStore keyStore = generateKey();
-            final String algo = KeyProperties.KEY_ALGORITHM_AES + "/" + KeyProperties.BLOCK_MODE_CBC + "/" + KeyProperties.ENCRYPTION_PADDING_PKCS7;
-            cipher = Cipher.getInstance(algo);
+            cipher = Cipher.getInstance(CIPHER_ALGO);
 
             keyStore.load(null);
-            SecretKey key = (SecretKey) keyStore.getKey(KEY_NAME, null);
-            cipher.init(Cipher.ENCRYPT_MODE, key);
+            cipher.init(Cipher.ENCRYPT_MODE, keyStore.getKey(KEY_NAME, null));
         } catch (Exception e) {
-            // ignored
+            // nothing we can do about it, return null
         }
 
         return cipher;
     }
 
-    @TargetApi(Build.VERSION_CODES.M)
     private KeyStore generateKey() throws Exception {
         final KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
         final KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore");

--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -58,7 +58,7 @@ public class FingerprintDialog extends DialogFragment
 
         mFingerprintImage.setColorFilter(color);
 
-        mFingerprintHandler = new FingerprintHandler(this.getContext(), this.getActivity().getSystemService(FingerprintManager.class), this);
+        mFingerprintHandler = new FingerprintHandler(this.getActivity().getSystemService(FingerprintManager.class), this);
 
         if (!mFingerprintHandler.isFingerprintAuthAvailable()) {
             dismiss(); //dismiss if fingerpint not available
@@ -80,8 +80,7 @@ public class FingerprintDialog extends DialogFragment
          {
             public boolean onKey(DialogInterface dialog, int keyCode, KeyEvent event){
             if (keyCode == KeyEvent.KEYCODE_BACK) {
-              dialogCallback.onCancelled();
-              dismiss();
+              mFingerprintHandler.endAuth();
               return true; // pretend we've processed it
             } else {
               return false; // pass on to be processed as normal

--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -1,134 +1,143 @@
 package com.rnfingerprint;
 
 import android.app.DialogFragment;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.hardware.fingerprint.FingerprintManager;
 import android.os.Bundle;
-import android.util.Log;
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
-import java.lang.String;
-import android.view.LayoutInflater;
-import android.view.ViewGroup;
-import android.content.DialogInterface;
-import android.view.KeyEvent;
+
 import com.facebook.react.bridge.ReadableMap;
-import android.hardware.fingerprint.FingerprintManager;
-import android.os.Handler.Callback;
 
-public class FingerprintDialog extends DialogFragment
-        implements FingerprintHandler.Callback {
-
-    private Button mCancelButton;
-    private View mFingerprintContent;
-    private TextView mFingerprintDescription;
-    private ImageView mFingerprintImage;
+public class FingerprintDialog extends DialogFragment implements FingerprintHandler.Callback {
 
     private FingerprintManager.CryptoObject mCryptoObject;
     private DialogResultListener dialogCallback;
     private FingerprintHandler mFingerprintHandler;
+    private boolean isAuthInProgress;
 
     private String authReason;
     private ReadableMap authConfig;
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);        
-        setStyle(DialogFragment.STYLE_NORMAL, android.R.style.Theme_Material_Light_Dialog);
+    public void onAttach(Context context) {
+        super.onAttach(context);
+
+        mFingerprintHandler = new FingerprintHandler(context, this);
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
-                             Bundle savedInstanceState) {
-
-
-        getDialog().setTitle(authConfig.getString("title"));
-        int color = authConfig.getInt("color");
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setStyle(DialogFragment.STYLE_NORMAL, android.R.style.Theme_Material_Light_Dialog);
 
         setCancelable(false);
+    }
 
-        View v = inflater.inflate(R.layout.fingerprint_dialog, container, false);
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        final View v = inflater.inflate(R.layout.fingerprint_dialog, container, false);
 
-        mFingerprintContent = v.findViewById(R.id.fingerprint_container);
-
-        mFingerprintDescription = (TextView) v.findViewById(R.id.fingerprint_description);
-
+        final TextView mFingerprintDescription = (TextView) v.findViewById(R.id.fingerprint_description);
         mFingerprintDescription.setText(authReason);
-        mFingerprintImage = (ImageView) v.findViewById(R.id.fingerprint_icon);
 
+        final int color = authConfig.getInt("color");
+        final ImageView mFingerprintImage = (ImageView) v.findViewById(R.id.fingerprint_icon);
         mFingerprintImage.setColorFilter(color);
 
-        mFingerprintHandler = new FingerprintHandler(this.getActivity().getSystemService(FingerprintManager.class), this);
-
-        if (!mFingerprintHandler.isFingerprintAuthAvailable()) {
-            dismiss(); //dismiss if fingerpint not available
-        } else {
-            mFingerprintHandler.startAuth(mCryptoObject);
-        }
-
-
-        mCancelButton = (Button) v.findViewById(R.id.cancel_button);
+        final Button mCancelButton = (Button) v.findViewById(R.id.cancel_button);
         mCancelButton.setTextColor(color);
         mCancelButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mFingerprintHandler.endAuth();
+                onCancelled();
             }
         });
 
-        getDialog().setOnKeyListener(new DialogInterface.OnKeyListener()
-         {
-            public boolean onKey(DialogInterface dialog, int keyCode, KeyEvent event){
-            if (keyCode == KeyEvent.KEYCODE_BACK) {
-              mFingerprintHandler.endAuth();
-              return true; // pretend we've processed it
-            } else {
-              return false; // pass on to be processed as normal
+        getDialog().setTitle(authConfig.getString("title"));
+        getDialog().setOnKeyListener(new DialogInterface.OnKeyListener() {
+            public boolean onKey(DialogInterface dialog, int keyCode, KeyEvent event) {
+                if (keyCode != KeyEvent.KEYCODE_BACK || mFingerprintHandler == null) {
+                    return false; // pass on to be processed as normal
+                }
+
+                onCancelled();
+                return true; // pretend we've processed it
             }
-          }
         });
 
         return v;
     }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        if (isAuthInProgress) {
+            return;
+        }
+
+        isAuthInProgress = true;
+        mFingerprintHandler.startAuth(mCryptoObject);
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+
+        mFingerprintHandler.endAuth();
+    }
+
 
     public void setCryptoObject(FingerprintManager.CryptoObject cryptoObject) {
         mCryptoObject = cryptoObject;
     }
 
     public void setDialogCallback(DialogResultListener newDialogCallback) {
-      dialogCallback = newDialogCallback;
+        dialogCallback = newDialogCallback;
     }
 
     public void setReasonForAuthentication(String reason) {
-      authReason = reason;
+        authReason = reason;
     }
 
     public void setAuthConfig(ReadableMap config) {
-      authConfig = config;
+        authConfig = config;
     }
 
     public interface DialogResultListener {
-      void onAuthenticated();
-      void onError(String errorString);
-      void onCancelled();
+        void onAuthenticated();
+
+        void onError(String errorString);
+
+        void onCancelled();
     }
 
     @Override
     public void onAuthenticated() {
+        isAuthInProgress = false;
         dialogCallback.onAuthenticated();
         dismiss();
     }
 
     @Override
     public void onError(String errorString) {
+        isAuthInProgress = false;
         dialogCallback.onError(errorString);
         dismiss();
     }
 
     @Override
     public void onCancelled() {
+        isAuthInProgress = false;
+        mFingerprintHandler.endAuth();
         dialogCallback.onCancelled();
         dismiss();
     }
-
 }

--- a/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
@@ -1,23 +1,19 @@
 package com.rnfingerprint;
-import android.Manifest;
-import android.content.Context;
-import android.content.pm.PackageManager;
+import android.annotation.TargetApi;
 import android.hardware.fingerprint.FingerprintManager;
+import android.os.Build;
 import android.os.CancellationSignal;
-import android.support.v4.app.ActivityCompat;
-import android.widget.Toast;
 
+@TargetApi(Build.VERSION_CODES.M)
 public class FingerprintHandler extends FingerprintManager.AuthenticationCallback {
 
     private CancellationSignal cancellationSignal;
     private boolean selfCancelled;
-    private Context mAppContext;
 
     private final FingerprintManager mFingerprintManager;
     private final Callback mCallback;
 
-    public FingerprintHandler(Context context, FingerprintManager fingerprintManager, Callback callback) {
-        mAppContext = context;
+    public FingerprintHandler(FingerprintManager fingerprintManager, Callback callback) {
         mFingerprintManager = fingerprintManager;
         mCallback = callback;
     }


### PR DESCRIPTION
1. Fixes the issue when back button is pressed -> dialog dismissed -> app crashes. Based on PR https://github.com/naoufal/react-native-touch-id/pull/120.
2. Auth module will do nothing if activity is not ready or app is in background. Fixes the issue when dialog is automatically displayed on `componentDidMount`, but we clicked `home` button while app is loading. As a result app crashed.
3. `FingerprintDialog` will start auth when it is visible instead of when the layout is created.
4. `FingerprintDialog` will cancel auth when view is destroyed.
5. Removed `RuntimeExceptions` so they would not crash the app. Instead module will call `errorCallback` on JS side.
6. Moved out cipher creation into a separate file.