### PR TITLE
Strict mode fix: explicitly declare variable DEFAULT_CONFIG

### DIFF
--- a/TouchID.android.js
+++ b/TouchID.android.js
@@ -17,7 +17,7 @@ export default {
   },
 
   authenticate(reason, config) {
-    DEFAULT_CONFIG = { title: 'Authentication Required', color: '#1306ff' };
+    var DEFAULT_CONFIG = { title: 'Authentication Required', color: '#1306ff' };
     var authReason = reason ? reason : ' ';
     var authConfig = Object.assign({}, DEFAULT_CONFIG, config);
     var color = processColor(authConfig.color);


### PR DESCRIPTION
Hello there, thanks for this awesome plugin.

Notes on this PR:

- No other changes to allow to merge this PR as simply as possible ^^

- The **strict mode** error does not always trigger, but I had the problem when deploying from macOS on android, the plugin would crash when the `authenticate `method is called in debug mode.

- If somebody has a idea whats could cause to **strict mode** enables itself in react-native and throw error, I would be thankful!

