### PR TITLE
Respect the Android lifecycle and stop listening for finger print actions when the dialog is not in-view anymore

### DIFF
--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -88,10 +88,13 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
     }
 
     @Override
-    public void onDestroyView() {
-        super.onDestroyView();
+    public void onPause() {
+        super.onPause();
 
-        mFingerprintHandler.endAuth();
+        if (isAuthInProgress) {
+            mFingerprintHandler.endAuth();
+            isAuthInProgress = false;
+        }
     }
 
 


### PR DESCRIPTION
This fixes https://github.com/naoufal/react-native-touch-id/issues/132