### PR TITLE
Fix #110 (missing LAError codes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,12 @@ Below is a list of error codes that can be returned **on iOS**:
 | `LAErrorUserFallback` | Authentication was canceled because the user tapped the fallback button (Enter Password). |
 | `LAErrorSystemCancel` | Authentication was canceled by system—for example, if another application came to foreground while the authentication dialog was up. |
 | `LAErrorPasscodeNotSet` | Authentication could not start because the passcode is not set on the device. |
-| `LAErrorTouchIDNotAvailable` | Authentication could not start because Touch ID is not available on the device |
+| `LAErrorBiometryNotAvailable` | Authentication could not start because Biometry is not available on the device. |
+| `LAErrorBiometryNotEnrolled` | Authentication could not start because Biometry has no enrolled biometric identities. |
+| `LAErrorBiometryLockout` | Authentication could not start because Biometry had too many failed attempts. |
+| `LAErrorTouchIDNotAvailable` | Authentication could not start because Touch ID is not available on the device. |
 | `LAErrorTouchIDNotEnrolled` | Authentication could not start because Touch ID has no enrolled fingers. |
+| `LAErrorTouchIDLockout` | Authentication could not start because Touch ID had too many failed attempts. |
 | `RCTTouchIDUnknownError` | Could not authenticate for an unknown reason. |
 | `RCTTouchIDNotSupported` | Device does not support Touch ID. |
 

--- a/README.md
+++ b/README.md
@@ -202,9 +202,6 @@ Below is a list of error codes that can be returned **on iOS**:
 | `LAErrorBiometryNotAvailable` | Authentication could not start because Biometry is not available on the device. |
 | `LAErrorBiometryNotEnrolled` | Authentication could not start because Biometry has no enrolled biometric identities. |
 | `LAErrorBiometryLockout` | Authentication could not start because Biometry had too many failed attempts. |
-| `LAErrorTouchIDNotAvailable` | Authentication could not start because Touch ID is not available on the device. |
-| `LAErrorTouchIDNotEnrolled` | Authentication could not start because Touch ID has no enrolled fingers. |
-| `LAErrorTouchIDLockout` | Authentication could not start because Touch ID had too many failed attempts. |
 | `RCTTouchIDUnknownError` | Could not authenticate for an unknown reason. |
 | `RCTTouchIDNotSupported` | Device does not support Touch ID. |
 

--- a/TouchID.m
+++ b/TouchID.m
@@ -65,6 +65,18 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
                          errorReason = @"LAErrorPasscodeNotSet";
                          break;
 
+                     case LAErrorBiometryNotAvailable:
+                         errorReason = @"LAErrorBiometryNotAvailable";
+                         break;
+
+                     case LAErrorBiometryNotEnrolled:
+                         errorReason = @"LAErrorBiometryNotEnrolled";
+                         break;
+
+                     case LAErrorBiometryLockout:
+                         errorReason = @"LAErrorBiometryLockout";
+                         break;
+
                      case LAErrorTouchIDNotAvailable:
                          errorReason = @"LAErrorTouchIDNotAvailable";
                          break;
@@ -73,6 +85,9 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
                          errorReason = @"LAErrorTouchIDNotEnrolled";
                          break;
 
+                     case LAErrorTouchIDLockout:
+                         errorReason = @"LAErrorTouchIDLockout";
+                         break;
                      default:
                          errorReason = @"RCTTouchIDUnknownError";
                          break;

--- a/TouchID.m
+++ b/TouchID.m
@@ -77,17 +77,6 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
                          errorReason = @"LAErrorBiometryLockout";
                          break;
 
-                     case LAErrorTouchIDNotAvailable:
-                         errorReason = @"LAErrorTouchIDNotAvailable";
-                         break;
-
-                     case LAErrorTouchIDNotEnrolled:
-                         errorReason = @"LAErrorTouchIDNotEnrolled";
-                         break;
-
-                     case LAErrorTouchIDLockout:
-                         errorReason = @"LAErrorTouchIDLockout";
-                         break;
                      default:
                          errorReason = @"RCTTouchIDUnknownError";
                          break;

--- a/data/errors.js
+++ b/data/errors.js
@@ -14,11 +14,23 @@ module.exports = {
   LAErrorPasscodeNotSet: {
     message: 'Authentication could not start because the passcode is not set on the device.'
   },
+  LAErrorBiometryNotAvailable: {
+    message: 'Authentication could not start because Biometry is not available on the device.'
+  },
+  LAErrorBiometryNotEnrolled: {
+    message: 'Authentication could not start because Biometry has no enrolled biometric identities.'
+  },
+  LAErrorBiometryLockout: {
+    message: 'Authentication could not start because Biometry had too many failed attempts.'
+  },
   LAErrorTouchIDNotAvailable: {
-    message: 'Authentication could not start because Touch ID is not available on the device'
+    message: 'Authentication could not start because Touch ID is not available on the device.'
   },
   LAErrorTouchIDNotEnrolled: {
     message: 'Authentication could not start because Touch ID has no enrolled fingers.'
+  },
+  LAErrorTouchIDLockout: {
+    message: 'Authentication could not start because Touch ID had too many failed attempts.'
   },
   RCTTouchIDUnknownError: {
     message: 'Could not authenticate for an unknown reason.'

--- a/data/errors.js
+++ b/data/errors.js
@@ -23,15 +23,6 @@ module.exports = {
   LAErrorBiometryLockout: {
     message: 'Authentication could not start because Biometry had too many failed attempts.'
   },
-  LAErrorTouchIDNotAvailable: {
-    message: 'Authentication could not start because Touch ID is not available on the device.'
-  },
-  LAErrorTouchIDNotEnrolled: {
-    message: 'Authentication could not start because Touch ID has no enrolled fingers.'
-  },
-  LAErrorTouchIDLockout: {
-    message: 'Authentication could not start because Touch ID had too many failed attempts.'
-  },
   RCTTouchIDUnknownError: {
     message: 'Could not authenticate for an unknown reason.'
   },

--- a/examples/BiometricAuthExample/App.js
+++ b/examples/BiometricAuthExample/App.js
@@ -99,8 +99,12 @@ const errors = {
   "LAErrorUserFallback": "Authentication was canceled because the user tapped the fallback button (Enter Password).",
   "LAErrorSystemCancel": "Authentication was canceled by system—for example, if another application came to foreground while the authentication dialog was up.",
   "LAErrorPasscodeNotSet": "Authentication could not start because the passcode is not set on the device.",
-  "LAErrorTouchIDNotAvailable": "Authentication could not start because Touch ID is not available on the device",
+  "LAErrorBiometryNotAvailable": "Authentication could not start because Biometry is not available on the device.",
+  "LAErrorBiometryNotEnrolled": "Authentication could not start because Biometry has no enrolled biometric identities.",
+  "LAErrorBiometryLockout": "Authentication could not start because Biometry had too many failed attempts.",
+  "LAErrorTouchIDNotAvailable": "Authentication could not start because Touch ID is not available on the device.",
   "LAErrorTouchIDNotEnrolled": "Authentication could not start because Touch ID has no enrolled fingers.",
+  "LAErrorTouchIDLockout": "Authentication could not start because Touch ID had too many failed attempts.",
   "RCTTouchIDUnknownError": "Could not authenticate for an unknown reason.",
   "RCTTouchIDNotSupported": "Device does not support Touch ID."
 };

--- a/examples/BiometricAuthExample/App.js
+++ b/examples/BiometricAuthExample/App.js
@@ -102,9 +102,6 @@ const errors = {
   "LAErrorBiometryNotAvailable": "Authentication could not start because Biometry is not available on the device.",
   "LAErrorBiometryNotEnrolled": "Authentication could not start because Biometry has no enrolled biometric identities.",
   "LAErrorBiometryLockout": "Authentication could not start because Biometry had too many failed attempts.",
-  "LAErrorTouchIDNotAvailable": "Authentication could not start because Touch ID is not available on the device.",
-  "LAErrorTouchIDNotEnrolled": "Authentication could not start because Touch ID has no enrolled fingers.",
-  "LAErrorTouchIDLockout": "Authentication could not start because Touch ID had too many failed attempts.",
   "RCTTouchIDUnknownError": "Could not authenticate for an unknown reason.",
   "RCTTouchIDNotSupported": "Device does not support Touch ID."
 };

--- a/examples/TouchIDExample/index.ios.js
+++ b/examples/TouchIDExample/index.ios.js
@@ -87,9 +87,6 @@ const errors = {
   "LAErrorBiometryNotAvailable": "Authentication could not start because Biometry is not available on the device.",
   "LAErrorBiometryNotEnrolled": "Authentication could not start because Biometry has no enrolled biometric identities.",
   "LAErrorBiometryLockout": "Authentication could not start because Biometry had too many failed attempts.",
-  "LAErrorTouchIDNotAvailable": "Authentication could not start because Touch ID is not available on the device.",
-  "LAErrorTouchIDNotEnrolled": "Authentication could not start because Touch ID has no enrolled fingers.",
-  "LAErrorTouchIDLockout": "Authentication could not start because Touch ID had too many failed attempts.",
   "RCTTouchIDUnknownError": "Could not authenticate for an unknown reason.",
   "RCTTouchIDNotSupported": "Device does not support Touch ID."
 };

--- a/examples/TouchIDExample/index.ios.js
+++ b/examples/TouchIDExample/index.ios.js
@@ -84,8 +84,12 @@ const errors = {
   "LAErrorUserFallback": "Authentication was canceled because the user tapped the fallback button (Enter Password).",
   "LAErrorSystemCancel": "Authentication was canceled by system—for example, if another application came to foreground while the authentication dialog was up.",
   "LAErrorPasscodeNotSet": "Authentication could not start because the passcode is not set on the device.",
-  "LAErrorTouchIDNotAvailable": "Authentication could not start because Touch ID is not available on the device",
+  "LAErrorBiometryNotAvailable": "Authentication could not start because Biometry is not available on the device.",
+  "LAErrorBiometryNotEnrolled": "Authentication could not start because Biometry has no enrolled biometric identities.",
+  "LAErrorBiometryLockout": "Authentication could not start because Biometry had too many failed attempts.",
+  "LAErrorTouchIDNotAvailable": "Authentication could not start because Touch ID is not available on the device.",
   "LAErrorTouchIDNotEnrolled": "Authentication could not start because Touch ID has no enrolled fingers.",
+  "LAErrorTouchIDLockout": "Authentication could not start because Touch ID had too many failed attempts.",
   "RCTTouchIDUnknownError": "Could not authenticate for an unknown reason.",
   "RCTTouchIDNotSupported": "Device does not support Touch ID."
 };


### PR DESCRIPTION
Adding new Biometry Failure LAError codes for iOS 11.0+
Issue: https://github.com/naoufal/react-native-touch-id/issues/110
LAError codes: https://developer.apple.com/documentation/localauthentication/laerror?language=objc