### PR TITLE
fix: remove deprecated React pod dependency

### DIFF
--- a/TouchID.podspec
+++ b/TouchID.podspec
@@ -14,5 +14,4 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/naoufal/react-native-touch-id.git" }
 
   s.source_files  = "*.{h,m}"
-  s.dependency "React"
 end


### PR DESCRIPTION
The React pod is deprecated and the last version is 0.11

Running `pod install` as described in the README breaks the project due to two react native versions being installed.

Fixes #157