### PR TITLE
Android: handle failed attempts with error message, icon color and description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,10 @@ __Arguments__
 
 - `config` - **optional** - configuration object for more detailed dialog setup:
   - `title` - **Android** - title of confirmation dialog
-  - `color` - **Android** - color of confirmation dialog
+  - `imageColor` - **Android** - color of fingerprint image
+  - `imageErrorColor` - **Android** - color of fingerprint image after failed attempt
   - `sensorDescription` - **Android** - text shown next to the fingerprint image
+  - `sensorErrorDescription` - **Android** - text shown next to the fingerprint image after failed attempt
   - `cancelText` - **Android** - cancel button text
   - `fallbackLabel` - **iOS** - by default specified 'Show Password' label. If set to empty string label is invisible.
   - `unifiedErrors` - return unified error messages (see below) (default = false)
@@ -157,8 +159,10 @@ __Examples__
 ```js
 const optionalConfigObject = {
   title: "Authentication Required", // Android
-  color: "#e00606", // Android
+  imageColor: "#e00606", // Android
+  imageErrorColor: "#ff0000", // Android
   sensorDescription: "Touch sensor", // Android
+  sensorErrorDescription: "Failed", // Android
   cancelText: "Cancel", // Android
   fallbackLabel: "Show Passcode", // iOS (if empty, then label is hidden)
   unifiedErrors: false // use unified error messages (default false)

--- a/TouchID.android.js
+++ b/TouchID.android.js
@@ -20,16 +20,20 @@ export default {
   authenticate(reason, config) {
     DEFAULT_CONFIG = {
       title: 'Authentication Required',
-      color: '#1306ff',
+      imageColor: '#1306ff',
+      imageErrorColor: '#ff0000',
       sensorDescription: 'Touch sensor',
+      sensorErrorDescription: 'Failed',
       cancelText: 'Cancel',
       unifiedErrors: false
     };
     var authReason = reason ? reason : ' ';
     var authConfig = Object.assign({}, DEFAULT_CONFIG, config);
-    var color = processColor(authConfig.color);
+    var imageColor = processColor(authConfig.imageColor);
+    var imageErrorColor = processColor(authConfig.imageErrorColor);
 
-    authConfig.color = color;
+    authConfig.imageColor = imageColor;
+    authConfig.imageErrorColor = imageErrorColor;
 
     return new Promise((resolve, reject) => {
       NativeTouchID.authenticate(

--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -22,11 +22,14 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
     private FingerprintHandler mFingerprintHandler;
     private boolean isAuthInProgress;
 
+    private TextView mFingerprintError;
+
     private String authReason;
     private int dialogColor = 0;
     private String dialogTitle = "";
     private String cancelText = "";
     private String sensorDescription = "";
+    private String errorText = "";
 
     @Override
     public void onAttach(Context context) {
@@ -56,6 +59,9 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
 
         final TextView mFingerprintSensorDescription = (TextView) v.findViewById(R.id.fingerprint_sensor_description);
         mFingerprintSensorDescription.setText(this.sensorDescription);
+
+        this.mFingerprintError = (TextView) v.findViewById(R.id.fingerprint_error);
+        this.mFingerprintError.setText(this.errorText);
 
         final Button mCancelButton = (Button) v.findViewById(R.id.cancel_button);
         mCancelButton.setText(this.cancelText);
@@ -155,9 +161,7 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
 
     @Override
     public void onError(String errorString, int errorCode) {
-        this.isAuthInProgress = false;
-        this.dialogCallback.onError(errorString, errorCode);
-        dismiss();
+        this.mFingerprintError.setText(errorString);
     }
 
     @Override

--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -22,13 +22,17 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
     private FingerprintHandler mFingerprintHandler;
     private boolean isAuthInProgress;
 
+    private ImageView mFingerprintImage;
+    private TextView mFingerprintSensorDescription;
     private TextView mFingerprintError;
 
     private String authReason;
-    private int dialogColor = 0;
+    private int imageColor = 0;
+    private int imageErrorColor = 0;
     private String dialogTitle = "";
     private String cancelText = "";
     private String sensorDescription = "";
+    private String sensorErrorDescription = "";
     private String errorText = "";
 
     @Override
@@ -52,13 +56,13 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
         final TextView mFingerprintDescription = (TextView) v.findViewById(R.id.fingerprint_description);
         mFingerprintDescription.setText(this.authReason);
 
-        final ImageView mFingerprintImage = (ImageView) v.findViewById(R.id.fingerprint_icon);
-        if (this.dialogColor != 0) {
-            mFingerprintImage.setColorFilter(this.dialogColor);
+        this.mFingerprintImage = (ImageView) v.findViewById(R.id.fingerprint_icon);
+        if (this.imageColor != 0) {
+            this.mFingerprintImage.setColorFilter(this.imageColor);
         }
 
-        final TextView mFingerprintSensorDescription = (TextView) v.findViewById(R.id.fingerprint_sensor_description);
-        mFingerprintSensorDescription.setText(this.sensorDescription);
+        this.mFingerprintSensorDescription = (TextView) v.findViewById(R.id.fingerprint_sensor_description);
+        this.mFingerprintSensorDescription.setText(this.sensorDescription);
 
         this.mFingerprintError = (TextView) v.findViewById(R.id.fingerprint_error);
         this.mFingerprintError.setText(this.errorText);
@@ -71,9 +75,6 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
                 onCancelled();
             }
         });
-        if (this.dialogColor != 0) {
-            mCancelButton.setTextColor(this.dialogColor);
-        }
 
         getDialog().setTitle(this.dialogTitle);
         getDialog().setOnKeyListener(new DialogInterface.OnKeyListener() {
@@ -105,7 +106,7 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
     @Override
     public void onPause() {
         super.onPause();
-        if (isAuthInProgress) {
+        if (this.isAuthInProgress) {
             this.mFingerprintHandler.endAuth();
             this.isAuthInProgress = false;
         }
@@ -132,15 +133,25 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
         if (config.hasKey("title")) {
             this.dialogTitle = config.getString("title");
         }
+
         if (config.hasKey("cancelText")) {
             this.cancelText = config.getString("cancelText");
         }
+
         if (config.hasKey("sensorDescription")) {
             this.sensorDescription = config.getString("sensorDescription");
         }
 
-        if (config.hasKey("color")) {
-            this.dialogColor = config.getInt("color");
+        if (config.hasKey("sensorErrorDescription")) {
+            this.sensorErrorDescription = config.getString("sensorErrorDescription");
+        }
+
+        if (config.hasKey("imageColor")) {
+            this.imageColor = config.getInt("imageColor");
+        }
+
+        if (config.hasKey("imageErrorColor")) {
+            this.imageErrorColor = config.getInt("imageErrorColor");
         }
     }
 
@@ -162,6 +173,8 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
     @Override
     public void onError(String errorString, int errorCode) {
         this.mFingerprintError.setText(errorString);
+        this.mFingerprintImage.setColorFilter(this.imageErrorColor);
+        this.mFingerprintSensorDescription.setText(this.sensorErrorDescription);
     }
 
     @Override

--- a/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
@@ -40,8 +40,7 @@ public class FingerprintHandler extends FingerprintManager.AuthenticationCallbac
 
     @Override
     public void onAuthenticationFailed() {
-        mCallback.onError("failed", FingerprintAuthConstants.AUTHENTICATION_FAILED);
-        cancelAuthenticationSignal();
+        mCallback.onError("Not recognized. Try again.", FingerprintAuthConstants.AUTHENTICATION_FAILED);
     }
 
     @Override

--- a/android/src/main/res/layout/fingerprint_dialog.xml
+++ b/android/src/main/res/layout/fingerprint_dialog.xml
@@ -16,10 +16,10 @@
         android:layout_height="wrap_content"
         android:layout_marginLeft="25dp"
         android:layout_marginRight="25dp"
-        android:layout_marginTop="20dp"
+        android:layout_marginTop="10dp"
         android:gravity="left"
         android:text="TextView"
-        android:textColor="#000"
+        android:textColor="#696969"
         android:textSize="17dp" />
 
 
@@ -28,14 +28,14 @@
         android:layout_height="wrap_content"
         android:gravity="center"
         android:orientation="horizontal"
-        android:paddingBottom="30dp"
+        android:paddingBottom="25dp"
         android:paddingRight="20dp"
-        android:paddingTop="28dp">
+        android:paddingTop="25dp">
 
         <ImageView
             android:id="@+id/fingerprint_icon"
-            android:layout_width="49dp"
-            android:layout_height="49dp"
+            android:layout_width="65dp"
+            android:layout_height="65dp"
             android:layout_marginLeft="25dp"
             android:gravity="left"
             android:src="@drawable/ic_fp_40px" />
@@ -74,6 +74,6 @@
         android:layout_marginEnd="10dp"
         android:background="#fff"
         android:text="Cancel"
-        android:textColor="#000" />
+        android:textColor="#696969" />
 
 </LinearLayout>

--- a/android/src/main/res/layout/fingerprint_dialog.xml
+++ b/android/src/main/res/layout/fingerprint_dialog.xml
@@ -51,6 +51,18 @@
             android:textSize="15dp" />
     </LinearLayout>
 
+    <TextView
+        android:id="@+id/fingerprint_error"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="25dp"
+        android:layout_marginRight="25dp"
+        android:layout_marginBottom="10dp"
+        android:gravity="center"
+        android:text="TextView"
+        android:textColor="#F00"
+        android:textSize="15dp" />
+
     <Button
         android:id="@+id/cancel_button"
         style="?android:attr/buttonBarButtonStyle"


### PR DESCRIPTION
- Current behaviour: Android, unlike iOS, closes the dialog after the first attempt. 
- Expected behaviour: Handle errors and allow system 5 attempts (default) before disabling sensor. Inform the user about the error.

Issue discussed [156](https://github.com/naoufal/react-native-touch-id/issues/156), [81](https://github.com/naoufal/react-native-touch-id/pull/81), [92](https://github.com/naoufal/react-native-touch-id/pull/92), [107](https://github.com/naoufal/react-native-touch-id/issues/107)

Updated UI:
<img width="1135" alt="screen shot 2018-10-12 at 11 52 21" src="https://user-images.githubusercontent.com/5912280/46881203-2aaca400-ce21-11e8-9b70-960a06755cad.png">

Updated config object:
- replaced `color` for `imageColor`
- added `imageErrorColor` (default: "#ff0000")
- added `sensorErrorDescription` (default: "Failed")

