### PR TITLE
Fix critical issue could not find intellij-core.jar

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,7 @@ android {
 }
 
 repositories {
+  google()
   mavenCentral()
 }
 


### PR DESCRIPTION
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':react-native-touch-id'.
> Could not resolve all files for configuration ':react-native-touch-id:classpath'.
   > Could not find intellij-core.jar (com.android.tools.external.com-intellij:intellij-core:26.0.1).
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/external/com-intellij/intellij-core/26.0.1/intellij-core-26.0.1.jar