### PR TITLE
return passcode if touchid is not available but a passcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,10 @@ TouchID.isSupported(optionalConfigObject)
     // Success code
     if (biometryType === 'FaceID') {
         console.log('FaceID is supported.');
-    } else {
+    } else if (biometryType == 'TouchID') {
         console.log('TouchID is supported.');
+    } else {
+        console.log('Passcode is supported.');
     }
   })
   .catch(error => {

--- a/TouchID.m
+++ b/TouchID.m
@@ -13,9 +13,9 @@ RCT_EXPORT_METHOD(isSupported: (RCTResponseSenderBlock)callback)
 
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
         callback(@[[NSNull null], [self getBiometryType:context]]);
-        
+
     } else if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error]) {
-        callback(@[[NSNull null], [self getBiometryType:context]]);
+        callback(@[[NSNull null], @"Passcode"]);
     }
     // Device does not support FaceID / TouchID / Pin
     else {
@@ -33,7 +33,7 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
     NSError *error;
 
     if (RCTNilIfNull([options objectForKey:@"fallbackLabel"]) != nil) {
-        NSString *fallbackLabel = [RCTConvert NSString:options[@"fallbackLabel"]];   
+        NSString *fallbackLabel = [RCTConvert NSString:options[@"fallbackLabel"]];
         context.localizedFallbackTitle = fallbackLabel;
     }
 
@@ -72,41 +72,41 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
         callback(@[[NSNull null], @"Authenticated with Touch ID."]);
     } else if (error) { // Authentication Error
         NSString *errorReason;
-        
+
         switch (error.code) {
             case LAErrorAuthenticationFailed:
                 errorReason = @"LAErrorAuthenticationFailed";
                 break;
-                
+
             case LAErrorUserCancel:
                 errorReason = @"LAErrorUserCancel";
                 break;
-                
+
             case LAErrorUserFallback:
                 errorReason = @"LAErrorUserFallback";
                 break;
-                
+
             case LAErrorSystemCancel:
                 errorReason = @"LAErrorSystemCancel";
                 break;
-                
+
             case LAErrorPasscodeNotSet:
                 errorReason = @"LAErrorPasscodeNotSet";
                 break;
-                
+
             case LAErrorTouchIDNotAvailable:
                 errorReason = @"LAErrorTouchIDNotAvailable";
                 break;
-                
+
             case LAErrorTouchIDNotEnrolled:
                 errorReason = @"LAErrorTouchIDNotEnrolled";
                 break;
-                
+
             default:
                 errorReason = @"RCTTouchIDUnknownError";
                 break;
         }
-        
+
         NSLog(@"Authentication failed: %@", errorReason);
         callback(@[RCTMakeError(errorReason, nil, nil)]);
     } else { // Authentication Failure


### PR DESCRIPTION
This should fix the issue that "TouchID" is returned even if its not enrolled. It will now return "Passcode" in iOS.