### PR TITLE
make isSupported return an error when TouchID and FaceID is not supported 

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,7 @@ TouchID.isSupported(optionalConfigObject)
     // Success code
     if (biometryType === 'FaceID') {
         console.log('FaceID is supported.');
-    } else if (biometryTyp === 'Passcode' ) {
-        console.log('Passcode is supported.');
-    }else {
+    } else {
         console.log('TouchID is supported.');
     }
   })

--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ TouchID.isSupported(optionalConfigObject)
     // Success code
     if (biometryType === 'FaceID') {
         console.log('FaceID is supported.');
-    } else {
+    } else if (biometryTyp === 'Passcode' ) {
+        console.log('Passcode is supported.');
+    }else {
         console.log('TouchID is supported.');
     }
   })

--- a/TouchID.m
+++ b/TouchID.m
@@ -14,10 +14,7 @@ RCT_EXPORT_METHOD(isSupported: (RCTResponseSenderBlock)callback)
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
         callback(@[[NSNull null], [self getBiometryType:context]]);
 
-    } else if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error]) {
-        callback(@[[NSNull null], @"Passcode"]);
-    }
-    // Device does not support FaceID / TouchID / Pin
+    } // Device does not support FaceID / TouchID
     else {
         callback(@[RCTMakeError(@"RCTTouchIDNotSupported", nil, nil)]);
         return;

--- a/TouchID.m
+++ b/TouchID.m
@@ -13,11 +13,8 @@ RCT_EXPORT_METHOD(isSupported: (RCTResponseSenderBlock)callback)
 
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
         callback(@[[NSNull null], [self getBiometryType:context]]);
-        
-    } else if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error]) {
-        callback(@[[NSNull null], [self getBiometryType:context]]);
-    }
-    // Device does not support FaceID / TouchID / Pin
+
+    } // Device does not support FaceID / TouchID
     else {
         callback(@[RCTMakeError(@"RCTTouchIDNotSupported", nil, nil)]);
         return;
@@ -33,7 +30,7 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
     NSError *error;
 
     if (RCTNilIfNull([options objectForKey:@"fallbackLabel"]) != nil) {
-        NSString *fallbackLabel = [RCTConvert NSString:options[@"fallbackLabel"]];   
+        NSString *fallbackLabel = [RCTConvert NSString:options[@"fallbackLabel"]];
         context.localizedFallbackTitle = fallbackLabel;
     }
 
@@ -72,41 +69,41 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
         callback(@[[NSNull null], @"Authenticated with Touch ID."]);
     } else if (error) { // Authentication Error
         NSString *errorReason;
-        
+
         switch (error.code) {
             case LAErrorAuthenticationFailed:
                 errorReason = @"LAErrorAuthenticationFailed";
                 break;
-                
+
             case LAErrorUserCancel:
                 errorReason = @"LAErrorUserCancel";
                 break;
-                
+
             case LAErrorUserFallback:
                 errorReason = @"LAErrorUserFallback";
                 break;
-                
+
             case LAErrorSystemCancel:
                 errorReason = @"LAErrorSystemCancel";
                 break;
-                
+
             case LAErrorPasscodeNotSet:
                 errorReason = @"LAErrorPasscodeNotSet";
                 break;
-                
+
             case LAErrorTouchIDNotAvailable:
                 errorReason = @"LAErrorTouchIDNotAvailable";
                 break;
-                
+
             case LAErrorTouchIDNotEnrolled:
                 errorReason = @"LAErrorTouchIDNotEnrolled";
                 break;
-                
+
             default:
                 errorReason = @"RCTTouchIDUnknownError";
                 break;
         }
-        
+
         NSLog(@"Authentication failed: %@", errorReason);
         callback(@[RCTMakeError(errorReason, nil, nil)]);
     } else { // Authentication Failure

--- a/TouchID.m
+++ b/TouchID.m
@@ -14,7 +14,10 @@ RCT_EXPORT_METHOD(isSupported: (RCTResponseSenderBlock)callback)
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
         callback(@[[NSNull null], [self getBiometryType:context]]);
 
-    } // Device does not support FaceID / TouchID
+    } else if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error]) {
+        callback(@[[NSNull null], @"Passcode"]);
+    }
+    // Device does not support FaceID / TouchID / Pin
     else {
         callback(@[RCTMakeError(@"RCTTouchIDNotSupported", nil, nil)]);
         return;


### PR DESCRIPTION
Due to recent changes "TouchID" is returned when "Passcode" is supported. I deleted this check, as most of the users don't expect to only return "TouchID" and "FaceID" not passcode.