### PR TITLE
Added typescript definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,112 @@
+declare module 'react-native-touch-id' {
+    /**
+     * The supported biometry type
+     */
+    type BiometryType = 'FaceID' | 'TouchID';
+  
+    /**
+     * Base config to pass to `TouchID.isSupported` and `TouchID.authenticate`
+     */
+    interface Config {
+      /**
+       * Return unified error messages
+       */
+      unifiedErrors?: boolean;
+    }
+  
+    /**
+     * Authentication config
+     */
+    export interface AuthenticateConfig extends Config {
+      /**
+       * **Android only** - Title of confirmation dialog
+       */
+      title?: string;
+      /**
+       * **Android only** - Color of fingerprint image
+       */
+      imageColor?: string;
+      /**
+       * **Android only** - Color of fingerprint image after failed attempt
+       */
+      imageErrorColor?: string;
+      /**
+       * **Android only** - Text shown next to the fingerprint image
+       */
+      sensorDescription?: string;
+      /**
+       * **Android only** - Text shown next to the fingerprint image after failed attempt
+       */
+      sensorErrorDescription?: string;
+      /**
+       * **Android only** - Cancel button text
+       */
+      cancelText?: string;
+      /**
+       * **iOS only** - By default specified 'Show Password' label. If set to empty string label is invisible.
+       */
+      fallbackLabel?: string;
+      /**
+       * **iOS only** - By default set to false. If set to true, will allow use of keypad passcode.
+       */
+      passcodeFallback?: boolean;
+    }
+    /**
+     * `isSupported` error code
+     */
+    type IsSupportedErrorCode =
+      | 'NOT_SUPPORTED'
+      | 'NOT_AVAILABLE'
+      | 'NOT_PRESENT'
+      | 'NOT_ENROLLED';
+  
+    /**
+     * `authenticate` error code
+     */
+    type AuthenticateErrorCode =
+      | IsSupportedErrorCode
+      | 'AUTHENTICATION_FAILED'
+      | 'USER_CANCELED'
+      | 'SYSTEM_CANCELED'
+      | 'TIMEOUT'
+      | 'LOCKOUT'
+      | 'LOCKOUT_PERMANENT'
+      | 'PROCESSING_ERROR'
+      | 'USER_FALLBACK'
+      | 'UNKNOWN_ERROR';
+  
+    /**
+     * Error returned from `authenticate`
+     */
+    export interface AuthenticationError {
+      name: 'TouchIDError';
+      message: string;
+      code: AuthenticateErrorCode;
+      details: string;
+    }
+    /**
+     * Error returned from `isSupported`
+     */
+    export interface IsSupportedError {
+      name: 'TouchIDError';
+      message: string;
+      code: IsSupportedErrorCode;
+      details: string;
+    }
+  
+    const TouchID: {
+      /**
+       *
+       * @param reason String that provides a clear reason for requesting authentication.
+       * @param config Configuration object for more detailed dialog setup
+       */
+      authenticate(reason?: string, config?: AuthenticateConfig);
+      /**
+       * 
+       * @param config - Returns a `Promise` that rejects if TouchID is not supported. On iOS resolves with a `biometryType` `String` of `FaceID` or `TouchID`
+       */
+      isSupported(config?: Config): Promise<BiometryType>;
+    };
+    export default TouchID;
+  }
+  

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare module 'react-native-touch-id' {
     /**
      * Base config to pass to `TouchID.isSupported` and `TouchID.authenticate`
      */
-    interface Config {
+    interface IsSupportedConfig {
       /**
        * Return unified error messages
        */
@@ -17,7 +17,7 @@ declare module 'react-native-touch-id' {
     /**
      * Authentication config
      */
-    export interface AuthenticateConfig extends Config {
+    export interface AuthenticateConfig extends IsSupportedConfig {
       /**
        * **Android only** - Title of confirmation dialog
        */
@@ -105,7 +105,7 @@ declare module 'react-native-touch-id' {
        * 
        * @param config - Returns a `Promise` that rejects if TouchID is not supported. On iOS resolves with a `biometryType` `String` of `FaceID` or `TouchID`
        */
-      isSupported(config?: Config): Promise<BiometryType>;
+      isSupported(config?: IsSupportedConfig): Promise<BiometryType>;
     };
     export default TouchID;
   }


### PR DESCRIPTION
I had a nasty crash because I had a typo, so I made a TypeScript definition file. I thought it would be useful for other users, too. 

Note that in when you're in a try catch, the catch clause variable cannot have a type annotation.

You can cast the error:

```typescript
// try...
catch (e) {
 const err = e as AuthenticationError;
 if(err.code === "NOT_AVAILABLE"){
    console.log('err')
 }
}
```

And you get nice intellisense for your errors:
<img width="617" alt="screenshot 2018-11-09 13 50 46" src="https://user-images.githubusercontent.com/5732291/48266173-7eada700-e426-11e8-8dc6-21d8b80414e7.png">

Let me know what you think. 