### PR TITLE
Fix/optional is supported config

### DIFF
--- a/TouchID.ios.js
+++ b/TouchID.ios.js
@@ -16,7 +16,7 @@ const { getError, TouchIDError, TouchIDUnifiedError } = require('./errors');
 export default {
   isSupported(config) {
     return new Promise((resolve, reject) => {
-      NativeTouchID.isSupported((error, biometryType) => {
+      NativeTouchID.isSupported(config, (error, biometryType) => {
         if (error) {
           return reject(createError(config, error.message));
         }


### PR DESCRIPTION
We needed the ability to detect if the user did have TouchID/FaceID but had not enrolled, the way it was handled before we could not access the error from the `canEvaluatePolicy` call due to it falling back to passcode.

This code changes that so you can optionally pass `config = { passcodeFallback: false }` to the `TouchID.isSupported()` call, by providing `false` you are able to get access to the correct error in case of the user not being enrolled.

Note: The default for `passcodeFallback` is set to `true` so this doesn't break backwards compatibility

Also, cleaned up the error handling inside the `TouchID.m` file.