### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,5 +45,5 @@ repositories {
 }
 
 dependencies {
-  compile "com.facebook.react:react-native:${_reactNativeVersion}"
+  implementation "com.facebook.react:react-native:${_reactNativeVersion}"
 }


### PR DESCRIPTION
To get rid of the following warning:
```
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```