### PR TITLE
[TypeScript] Add return type for authenticate

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,7 +100,7 @@ declare module 'react-native-touch-id' {
        * @param reason String that provides a clear reason for requesting authentication.
        * @param config Configuration object for more detailed dialog setup
        */
-      authenticate(reason?: string, config?: AuthenticateConfig);
+      authenticate(reason?: string, config?: AuthenticateConfig): Promise<true>;
       /**
        * 
        * @param config - Returns a `Promise` that rejects if TouchID is not supported. On iOS resolves with a `biometryType` `String` of `FaceID` or `TouchID`

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "npm run lint"
   },
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/naoufal/react-native-touch-id.git"


### PR DESCRIPTION
And explicitly include the type file in `package.json`.

Please publish a new version of this awesome library, so we get automatic types. (The types were added after the latest version, so they're not published on npm yet.)