### PR TITLE
Prevent Null Object References When Calling DialogResultListener Methods

### DIFF
--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -166,7 +166,9 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
     @Override
     public void onAuthenticated() {
         this.isAuthInProgress = false;
-        this.dialogCallback.onAuthenticated();
+        if(this.dialogCallback != null){
+            this.dialogCallback.onAuthenticated();
+        }
         dismiss();
     }
 
@@ -181,7 +183,9 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
     public void onCancelled() {
         this.isAuthInProgress = false;
         this.mFingerprintHandler.endAuth();
-        this.dialogCallback.onCancelled();
+        if(this.dialogCallback != null){
+            this.dialogCallback.onCancelled();
+        }
         dismiss();
     }
 }


### PR DESCRIPTION
Ran into a number of fatal errors with this form (e.i issue #151 ):

Attempt to invoke interface method 'void com.rnfingerprint.FingerprintDialog$DialogResultListener.{INSERT_DIALOG_RESULT_LISTENER_INTERFACE_METHOD}' on a null object reference"

Using v4.0.4 but latest version doesn't appear to have any new logic that prevents this problem other than removing a call to DialogResultListener.onError. onAuthenticate and onCancelled are still called, sometimes causing this error. 