### PR TITLE
update: add LAErrorTouchIDLockout for iOS error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Format:
 | `LAErrorPasscodeNotSet`       | Authentication could not start because the passcode is not set on the device.                                                        |
 | `LAErrorTouchIDNotAvailable`  | Authentication could not start because Touch ID is not available on the device                                                       |
 | `LAErrorTouchIDNotEnrolled`   | Authentication could not start because Touch ID has no enrolled fingers.                                                             |
+| `LAErrorTouchIDLockout`       | Authentication failed because of too many failed attempts.                                                                               |
 | `RCTTouchIDUnknownError`      | Could not authenticate for an unknown reason.                                                                                        |
 | `RCTTouchIDNotSupported`      | Device does not support Touch ID.                                                                                                    |
 

--- a/TouchID.m
+++ b/TouchID.m
@@ -137,6 +137,10 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
         case LAErrorTouchIDNotEnrolled:
             errorReason = @"LAErrorTouchIDNotEnrolled";
             break;
+
+        case LAErrorTouchIDLockout:
+            errorReason = @"LAErrorTouchIDLockout";
+            break;
             
         default:
             errorReason = @"RCTTouchIDUnknownError";

--- a/data/errors.js
+++ b/data/errors.js
@@ -7,6 +7,7 @@ const codes = {
     LAErrorPasscodeNotSet: 'LAErrorPasscodeNotSet',
     LAErrorTouchIDNotAvailable: 'LAErrorTouchIDNotAvailable',
     LAErrorTouchIDNotEnrolled: 'LAErrorTouchIDNotEnrolled',
+    LAErrorTouchIDLockout: 'LAErrorTouchIDLockout',
     RCTTouchIDNotSupported: 'RCTTouchIDNotSupported',
     RCTTouchIDUnknownError: 'RCTTouchIDUnknownError'
   },
@@ -54,6 +55,9 @@ const iOSErrors = {
   },
   [codes.iOSCodes.LAErrorTouchIDNotEnrolled]: {
     message: 'Authentication could not start because Touch ID has no enrolled fingers.'
+  },
+  [codes.iOSCodes.LAErrorTouchIDLockout]: {
+    message: 'Authentication failed because of too many failed attempts.'
   },
   [codes.iOSCodes.RCTTouchIDUnknownError]: {
     message: 'Could not authenticate for an unknown reason.'

--- a/errors.js
+++ b/errors.js
@@ -72,6 +72,9 @@ const getError = (code) => {
   case codes.iOSCodes.LAErrorUserFallback:
     return errors.USER_FALLBACK;
 
+    case codes.iOSCodes.LAErrorTouchIDLockout:
+      return errors.LOCKOUT;
+
   default:
     return errors.UNKNOWN_ERROR;
   }

--- a/errors.js
+++ b/errors.js
@@ -72,8 +72,8 @@ const getError = (code) => {
   case codes.iOSCodes.LAErrorUserFallback:
     return errors.USER_FALLBACK;
 
-    case codes.iOSCodes.LAErrorTouchIDLockout:
-      return errors.LOCKOUT;
+  case codes.iOSCodes.LAErrorTouchIDLockout:
+    return errors.LOCKOUT;
 
   default:
     return errors.UNKNOWN_ERROR;


### PR DESCRIPTION
Add LAErrorTouchIDLockout error codes for iOS platform when Touch ID is locked because there were too many failed attempts - such as five times failed. this error code is also necessary for some users, I think. Thanks a lot.