### PR TITLE
Fix "Crypto primitive not initialized" 

### DIFF
--- a/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
@@ -6,6 +6,8 @@ import android.os.Build;
 import android.content.Context;
 import android.os.CancellationSignal;
 
+import java.lang.IllegalStateException;
+
 @TargetApi(Build.VERSION_CODES.M)
 public class FingerprintHandler extends FingerprintManager.AuthenticationCallback {
 
@@ -23,8 +25,11 @@ public class FingerprintHandler extends FingerprintManager.AuthenticationCallbac
     public void startAuth(FingerprintManager.CryptoObject cryptoObject) {
         cancellationSignal = new CancellationSignal();
         selfCancelled = false;
-        mFingerprintManager.authenticate(cryptoObject, cancellationSignal, 0, this, null);
-    }
+        try {
+            mFingerprintManager.authenticate(cryptoObject, cancellationSignal, 0, this, null);
+        } catch (IllegalStateException e) {
+            //prevent "Fatal Exception: java.lang.IllegalStateException: Crypto primitive not initialized"
+        }
 
     public void endAuth() {
         cancelAuthenticationSignal();


### PR DESCRIPTION
`Fatal Exception: java.lang.IllegalStateException: Crypto primitive not initialized
       at android.security.keystore.AndroidKeyStoreProvider.getKeyStoreOperationHandle(AndroidKeyStoreProvider.java:179)
       at android.hardware.biometrics.CryptoObject.getOpId(CryptoObject.java:77)
       at android.hardware.fingerprint.FingerprintManager.authenticate(FingerprintManager.java:488)
       at android.hardware.fingerprint.FingerprintManager.authenticate(FingerprintManager.java:447)
       at com.rnfingerprint.FingerprintHandler.startAuth(FingerprintHandler.java:26)
       at com.rnfingerprint.FingerprintDialog.onResume(FingerprintDialog.java:90)
       at android.app.Fragment.performResume(Fragment.java:2568)
       at android.app.FragmentManagerImpl.moveToState(FragmentManager.java:1341)
       at android.app.FragmentManagerImpl.moveFragmentToExpectedState(FragmentManager.java:1576)
       at android.app.FragmentManagerImpl.moveToState(FragmentManager.java:1637)
       at android.app.FragmentManagerImpl.executeOpsTogether(FragmentManager.java:2219)
       at android.app.FragmentManagerImpl.removeRedundantOperationsAndExecute(FragmentManager.java:2165)
       at android.app.FragmentManagerImpl.execPendingActions(FragmentManager.java:2066)
       at android.app.FragmentManagerImpl$1.run(FragmentManager.java:738)
       at android.os.Handler.handleCallback(Handler.java:873)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:214)
       at android.app.ActivityThread.main(ActivityThread.java:6981)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1445)`