### PR TITLE
[Android] Dismiss the fingerprint dialog on `onPause`

### DIFF
--- a/TouchID.ios.js
+++ b/TouchID.ios.js
@@ -14,6 +14,10 @@ const { getError, TouchIDError, TouchIDUnifiedError } = require('./errors');
  */
 
 export default {
+  invalidate() {
+    NativeTouchID.invalidate();
+  },
+
   isSupported(config) {
     return new Promise((resolve, reject) => {
       NativeTouchID.isSupported(config, (error, biometryType) => {

--- a/TouchID.m
+++ b/TouchID.m
@@ -6,6 +6,12 @@
 
 RCT_EXPORT_MODULE();
 
+RCT_EXPORT_METHOD(invalidate) {
+    LAContext *context = [[LAContext alloc] init];
+    
+    [context invalidate];
+}
+
 RCT_EXPORT_METHOD(isSupported: (NSDictionary *)options
                   callback: (RCTResponseSenderBlock)callback)
 {

--- a/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
@@ -74,9 +74,11 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule implements
         final Activity activity = getCurrentActivity();
 
         if (inProgress && fingerprintDialog != null && activity != null) {
-          fingerprintDialog.show(activity.getFragmentManager(), FRAGMENT_TAG);
+            if (activity.getFragmentManager().findFragmentByTag(FRAGMENT_TAG) == null) {
+                fingerprintDialog.show(activity.getFragmentManager(), FRAGMENT_TAG);
+            }
 
-          return;
+            return;
         }
 
         if (inProgress || !isAppActive || activity == null) {

--- a/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
@@ -20,6 +20,7 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule implements
 
     private static final String FRAGMENT_TAG = "fingerprint_dialog";
 
+    private FingerprintDialog fingerprintDialog;
     private KeyguardManager keyguardManager;
     private boolean isAppActive;
 
@@ -27,6 +28,8 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule implements
 
     public FingerprintAuthModule(final ReactApplicationContext reactContext) {
         super(reactContext);
+
+        fingerprintDialog = new FingerprintDialog();
 
         reactContext.addLifecycleEventListener(this);
     }
@@ -69,6 +72,13 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule implements
     @ReactMethod
     public void authenticate(final String reason, final ReadableMap authConfig, final Callback reactErrorCallback, final Callback reactSuccessCallback) {
         final Activity activity = getCurrentActivity();
+
+        if (inProgress && fingerprintDialog != null && activity != null) {
+          fingerprintDialog.show(activity.getFragmentManager(), FRAGMENT_TAG);
+
+          return;
+        }
+
         if (inProgress || !isAppActive || activity == null) {
             return;
         }
@@ -96,7 +106,6 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule implements
 
         final DialogResultHandler drh = new DialogResultHandler(reactErrorCallback, reactSuccessCallback);
 
-        final FingerprintDialog fingerprintDialog = new FingerprintDialog();
         fingerprintDialog.setCryptoObject(cryptoObject);
         fingerprintDialog.setReasonForAuthentication(reason);
         fingerprintDialog.setAuthConfig(authConfig);

--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -106,6 +106,9 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
     @Override
     public void onPause() {
         super.onPause();
+
+        dismiss();
+
         if (this.isAuthInProgress) {
             this.mFingerprintHandler.endAuth();
             this.isAuthInProgress = false;


### PR DESCRIPTION
Hi,

this PR attempts to fix a crash on Android that occurs if the system kills the app while it is on background with the fingerprint dialog opened.

There are some open issues that should probably be fixed by this PR:
https://github.com/naoufal/react-native-touch-id/issues/151
https://github.com/naoufal/react-native-touch-id/issues/198