### PR TITLE
[Types] added true to BiometryType for Android

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ declare module 'react-native-touch-id' {
     /**
      * The supported biometry type
      */
-    type BiometryType = 'FaceID' | 'TouchID';
+    type BiometryType = 'FaceID' | 'TouchID' | true;
   
     /**
      * Base config to pass to `TouchID.isSupported` and `TouchID.authenticate`


### PR DESCRIPTION
The promise for `isSupported` simply returns as true for Android but was missing from the types