### PR TITLE
[Types] added namespace

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,112 +1,115 @@
-declare module 'react-native-touch-id' {
-    /**
-     * The supported biometry type
-     */
-    type BiometryType = 'FaceID' | 'TouchID';
-  
-    /**
-     * Base config to pass to `TouchID.isSupported` and `TouchID.authenticate`
-     */
-    interface IsSupportedConfig {
-      /**
-       * Return unified error messages
-       */
-      unifiedErrors?: boolean;
+declare module "react-native-touch-id" {
+    namespace ReactNativeTouchID {
+        /**
+         * The supported biometry type
+         */
+        type BiometryType = "FaceID" | "TouchID";
+
+        /**
+         * Base config to pass to `TouchID.isSupported` and `TouchID.authenticate`
+         */
+        interface IsSupportedConfig {
+            /**
+             * Return unified error messages
+             */
+            unifiedErrors?: boolean;
+        }
+
+        /**
+         * Authentication config
+         */
+        interface AuthenticateConfig extends IsSupportedConfig {
+            /**
+             * **Android only** - Title of confirmation dialog
+             */
+            title?: string;
+            /**
+             * **Android only** - Color of fingerprint image
+             */
+            imageColor?: string;
+            /**
+             * **Android only** - Color of fingerprint image after failed attempt
+             */
+            imageErrorColor?: string;
+            /**
+             * **Android only** - Text shown next to the fingerprint image
+             */
+            sensorDescription?: string;
+            /**
+             * **Android only** - Text shown next to the fingerprint image after failed attempt
+             */
+            sensorErrorDescription?: string;
+            /**
+             * **Android only** - Cancel button text
+             */
+            cancelText?: string;
+            /**
+             * **iOS only** - By default specified "Show Password" label. If set to empty string label is invisible.
+             */
+            fallbackLabel?: string;
+            /**
+             * **iOS only** - By default set to false. If set to true, will allow use of keypad passcode.
+             */
+            passcodeFallback?: boolean;
+        }
+
+        /**
+         * `isSupported` error code
+         */
+        type IsSupportedErrorCode =
+            | "NOT_SUPPORTED"
+            | "NOT_AVAILABLE"
+            | "NOT_PRESENT"
+            | "NOT_ENROLLED";
+
+        /**
+         * `authenticate` error code
+         */
+        type AuthenticateErrorCode =
+            | IsSupportedErrorCode
+            | "AUTHENTICATION_FAILED"
+            | "USER_CANCELED"
+            | "SYSTEM_CANCELED"
+            | "TIMEOUT"
+            | "LOCKOUT"
+            | "LOCKOUT_PERMANENT"
+            | "PROCESSING_ERROR"
+            | "USER_FALLBACK"
+            | "UNKNOWN_ERROR";
+
+        /**
+         * Error returned from `authenticate`
+         */
+        interface AuthenticationError {
+            name: "TouchIDError";
+            message: string;
+            code: AuthenticateErrorCode;
+            details: string;
+        }
+        /**
+         * Error returned from `isSupported`
+         */
+        interface IsSupportedError {
+            name: "TouchIDError";
+            message: string;
+            code: IsSupportedErrorCode;
+            details: string;
+        }
     }
-  
-    /**
-     * Authentication config
-     */
-    export interface AuthenticateConfig extends IsSupportedConfig {
-      /**
-       * **Android only** - Title of confirmation dialog
-       */
-      title?: string;
-      /**
-       * **Android only** - Color of fingerprint image
-       */
-      imageColor?: string;
-      /**
-       * **Android only** - Color of fingerprint image after failed attempt
-       */
-      imageErrorColor?: string;
-      /**
-       * **Android only** - Text shown next to the fingerprint image
-       */
-      sensorDescription?: string;
-      /**
-       * **Android only** - Text shown next to the fingerprint image after failed attempt
-       */
-      sensorErrorDescription?: string;
-      /**
-       * **Android only** - Cancel button text
-       */
-      cancelText?: string;
-      /**
-       * **iOS only** - By default specified 'Show Password' label. If set to empty string label is invisible.
-       */
-      fallbackLabel?: string;
-      /**
-       * **iOS only** - By default set to false. If set to true, will allow use of keypad passcode.
-       */
-      passcodeFallback?: boolean;
-    }
-    /**
-     * `isSupported` error code
-     */
-    type IsSupportedErrorCode =
-      | 'NOT_SUPPORTED'
-      | 'NOT_AVAILABLE'
-      | 'NOT_PRESENT'
-      | 'NOT_ENROLLED';
-  
-    /**
-     * `authenticate` error code
-     */
-    type AuthenticateErrorCode =
-      | IsSupportedErrorCode
-      | 'AUTHENTICATION_FAILED'
-      | 'USER_CANCELED'
-      | 'SYSTEM_CANCELED'
-      | 'TIMEOUT'
-      | 'LOCKOUT'
-      | 'LOCKOUT_PERMANENT'
-      | 'PROCESSING_ERROR'
-      | 'USER_FALLBACK'
-      | 'UNKNOWN_ERROR';
-  
-    /**
-     * Error returned from `authenticate`
-     */
-    export interface AuthenticationError {
-      name: 'TouchIDError';
-      message: string;
-      code: AuthenticateErrorCode;
-      details: string;
-    }
-    /**
-     * Error returned from `isSupported`
-     */
-    export interface IsSupportedError {
-      name: 'TouchIDError';
-      message: string;
-      code: IsSupportedErrorCode;
-      details: string;
-    }
-  
-    const TouchID: {
-      /**
-       *
-       * @param reason String that provides a clear reason for requesting authentication.
-       * @param config Configuration object for more detailed dialog setup
-       */
-      authenticate(reason?: string, config?: AuthenticateConfig);
-      /**
-       * 
-       * @param config - Returns a `Promise` that rejects if TouchID is not supported. On iOS resolves with a `biometryType` `String` of `FaceID` or `TouchID`
-       */
-      isSupported(config?: IsSupportedConfig): Promise<BiometryType>;
+
+     const TouchID: {
+        /**
+         *
+         * @param reason String that provides a clear reason for requesting authentication.
+         * @param config Configuration object for more detailed dialog setup
+         */
+        authenticate(reason?: string, config?: ReactNativeTouchID.AuthenticateConfig);
+        /**
+         * 
+         * @param config - Returns a `Promise` that rejects if TouchID is not supported. On iOS resolves with a `biometryType` `String` of `FaceID` or `TouchID`
+         */
+        isSupported(config?: ReactNativeTouchID.IsSupportedConfig): Promise<ReactNativeTouchID.BiometryType>;
     };
+
     export default TouchID;
-  }
-  
+}


### PR DESCRIPTION
Added namespace to types so it's possible to override incorrect types in a `declarations.d.ts` file until the module is correctly patched

Edit: explanation
https://www.typescriptlang.org/docs/handbook/declaration-merging.html#merging-namespaces

in TypeScript, it's possible to merge namespaces so if I wanted to fix the `BiometryType` locally whilst I wait for the PR to be merged, I could have added the following to my `declarations.d.ts` which means other developers on my team would also have the patch:

```ts
declare module "react-native-touch-id" {
    namespace ReactNativeTouchID {
        type BiometryType: 'FaceID' | 'TouchID' | true;
    }

    const TouchID: {
        /**
         *
         * @param reason String that provides a clear reason for requesting authentication.
         * @param config Configuration object for more detailed dialog setup
         */
        authenticate(reason?: string, config?: ReactNativeTouchID.AuthenticateConfig);
        /**
         * 
         * @param config - Returns a `Promise` that rejects if TouchID is not supported. On iOS resolves with a `biometryType` `String` of `FaceID` or `TouchID`
         */
        isSupported(config?: ReactNativeTouchID.IsSupportedConfig): Promise<ReactNativeTouchID.BiometryType>;
    };

    export default TouchID;
}
```