### PR TITLE
Revise android module to return the biometry type supported

### DIFF
--- a/TouchID.android.js
+++ b/TouchID.android.js
@@ -10,8 +10,8 @@ export default {
         (error, code) => {
           return reject(createError(config, error, code));
         },
-        success => {
-          return resolve(true);
+        (biometryType) => {
+          return resolve(biometryType);
         }
       );
     });

--- a/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
@@ -59,7 +59,10 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule implements
 
         int result = isFingerprintAuthAvailable();
         if (result == FingerprintAuthConstants.IS_SUPPORTED) {
-            reactSuccessCallback.invoke("Is supported.");
+            // TODO: once this package supports Android's Face Unlock,
+            // implement a method to find out which type of biometry
+            // (not just fingerprint) is actually supported
+            reactSuccessCallback.invoke("Fingerprint");
         } else {
             reactErrorCallback.invoke("Not supported.", result);
         }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ declare module 'react-native-touch-id' {
     /**
      * The supported biometry type
      */
-    type BiometryType = 'FaceID' | 'TouchID';
+    type BiometryType = 'FaceID' | 'TouchID' | 'Fingerprint';
   
     /**
      * Base config to pass to `TouchID.isSupported` and `TouchID.authenticate`


### PR DESCRIPTION
This PR addresses issue #155 and returns "Fingerprint" if the device supports it, instead of a boolean true.