### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,21 +1,23 @@
 // Inspired by rayronvictor's PR #248 tp react-native-config
 // https://github.com/luggit/react-native-config/pull/248
 
-buildscript {
-  ext.safeExtGet = {prop, fallback ->
-        rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-  }
-  repositories {
-    maven {
-      url 'https://maven.google.com/'
-      name 'Google'
-    }
-    jcenter()
-    google()
-  }
+def safeExtGet(prop, fallback) {
+	rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
-  dependencies {
-    classpath("com.android.tools.build:gradle:${safeExtGet('gradlePluginVersion', '3.4.1')}")
+buildscript {
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+      repositories {
+        google()
+        jcenter()
+      }
+      
+      dependencies {
+          classpath("com.android.tools.build:gradle:3.5.3")
+      }
   }
 }
 
@@ -41,5 +43,5 @@ repositories {
 }
 
 dependencies {
-  implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
+  implementation "com.facebook.react:react-native:+"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,11 @@
 // Inspired by rayronvictor's PR #248 tp react-native-config
 // https://github.com/luggit/react-native-config/pull/248
 
-def _ext = rootProject.ext
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+def gradlePluginVersion = safeExtGet('gradlePluginVersion', '3.4.0')
 
 buildscript {
   repositories {
@@ -14,25 +18,19 @@ buildscript {
   }
 
   dependencies {
-    classpath _ext.has('gradleBuildTools') ? _ext.gradleBuildTools : 'com.android.tools.build:gradle:3.4.0'
+    classpath("com.android.tools.build:gradle:$gradlePluginVersion")
   }
 }
 
 apply plugin: 'com.android.library'
 
-def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
-def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 27
-def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '27.0.3'
-def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
-def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 27
-
 android {
-  compileSdkVersion _compileSdkVersion
-  buildToolsVersion _buildToolsVersion
+  compileSdkVersion safeExtGet('compileSdkVersion', 28)
+  buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
   defaultConfig {
-    minSdkVersion _minSdkVersion
-    targetSdkVersion _targetSdkVersion
+    minSdkVersion safeExtGet('minSdkVersion', 16)
+    targetSdkVersion safeExtGet('targetSdkVersion', 28)
     versionCode 1
     versionName "1.0"
   }
@@ -46,5 +44,5 @@ repositories {
 }
 
 dependencies {
-  implementation "com.facebook.react:react-native:${_reactNativeVersion}"
+  implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,13 +1,10 @@
 // Inspired by rayronvictor's PR #248 tp react-native-config
 // https://github.com/luggit/react-native-config/pull/248
 
-def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-}
-
-def gradlePluginVersion = safeExtGet('gradlePluginVersion', '3.4.0')
-
 buildscript {
+  ext.safeExtGet = {prop, fallback ->
+        rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+  }
   repositories {
     maven {
       url 'https://maven.google.com/'
@@ -18,7 +15,7 @@ buildscript {
   }
 
   dependencies {
-    classpath("com.android.tools.build:gradle:$gradlePluginVersion")
+    classpath("com.android.tools.build:gradle:${safeExtGet('gradlePluginVersion', '3.4.1')}")
   }
 }
 


### PR DESCRIPTION
refactored duplicate code and extracted them into a method

Additionally, this wraps the Android Gradle plugin dependency in the buildscripts section of android/build.gradle in a conditional:

```
if (project == rootProject) {
    // ... (dependency here)
}
```

The Android Gradle plugin is only required when opening the project stand-alone, not when it is included as a dependency. By doing this, the project opens correctly in Android Studio, and it can also be consumed as a native module dependency from an application project without affecting the app project (avoiding unnecessary downloads/conflicts/etc).

for more info, you can refer to [this thread](https://github.com/facebook/react-native/pull/25569) and especially [this comment.](https://github.com/facebook/react-native/pull/25569#issuecomment-532504277)