### PR TITLE
add passcode fallback on iOS and Android

### DIFF
--- a/TouchID.m
+++ b/TouchID.m
@@ -62,7 +62,7 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
     // Device has TouchID
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
         // Attempt Authentification
-        [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+        [context evaluatePolicy:LAPolicyDeviceOwnerAuthentication
                 localizedReason:reason
                           reply:^(BOOL success, NSError *error)
          {

--- a/android/src/main/java/com/rnfingerprint/KeyguardDialog.java
+++ b/android/src/main/java/com/rnfingerprint/KeyguardDialog.java
@@ -1,0 +1,66 @@
+package com.rnfingerprint;
+
+import android.app.Activity;
+import android.app.DialogFragment;
+import android.app.KeyguardManager;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+public class KeyguardDialog extends DialogFragment implements KeyguardHandler.Callback{
+    private KeyguardManager mKeyguardManager;
+    private KeyguardResultListener keyguardCallback;
+    private int PROMPT_FOR_KEYGUARD = 1;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        this.mKeyguardManager = (KeyguardManager) getActivity().getSystemService(Context.KEYGUARD_SERVICE);
+    }
+
+    @Override
+    public View onCreateView(final LayoutInflater inflater, final ViewGroup container, final Bundle savedInstanceState) {
+        final View v = inflater.inflate(R.layout.keyguard_dialog, container, false);
+
+        Intent intent = mKeyguardManager.createConfirmDeviceCredentialIntent(null, null);
+        startActivityForResult(intent, PROMPT_FOR_KEYGUARD);
+
+        return v;
+    }
+
+    public void setDialogCallback(KeyguardResultListener newDialogCallback) {
+        this.keyguardCallback = newDialogCallback;
+    }
+
+    public interface KeyguardResultListener {
+        void onAuthenticated();
+
+        void onCancelled();
+
+    }
+
+    @Override
+    public void onAuthenticated() {
+        this.keyguardCallback.onAuthenticated();
+        dismiss();
+    }
+
+    @Override
+    public void onCancelled() {
+        this.keyguardCallback.onCancelled();
+        dismiss();
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (resultCode == Activity.RESULT_OK) {
+            onAuthenticated();
+        } else if (resultCode == Activity.RESULT_CANCELED) {
+            onCancelled();
+        }
+    }
+}

--- a/android/src/main/java/com/rnfingerprint/KeyguardHandler.java
+++ b/android/src/main/java/com/rnfingerprint/KeyguardHandler.java
@@ -1,0 +1,10 @@
+package com.rnfingerprint;
+
+public class KeyguardHandler {
+
+    public interface Callback {
+        void onAuthenticated();
+
+        void onCancelled();
+    }
+}

--- a/android/src/main/java/com/rnfingerprint/KeyguardResultHandler.java
+++ b/android/src/main/java/com/rnfingerprint/KeyguardResultHandler.java
@@ -1,0 +1,25 @@
+package com.rnfingerprint;
+
+import com.facebook.react.bridge.Callback;
+
+public class KeyguardResultHandler implements KeyguardDialog.KeyguardResultListener  {
+    private Callback errorCallback;
+    private Callback successCallback;
+
+    public KeyguardResultHandler(Callback reactErrorCallback, Callback reactSuccessCallback) {
+        errorCallback = reactErrorCallback;
+        successCallback = reactSuccessCallback;
+    }
+
+    @Override
+    public void onAuthenticated() {
+        FingerprintAuthModule.inProgress = false;
+        successCallback.invoke("Successfully authenticated.");
+    }
+
+    @Override
+    public void onCancelled() {
+        FingerprintAuthModule.inProgress = false;
+        errorCallback.invoke("cancelled", FingerprintAuthConstants.AUTHENTICATION_CANCELED);
+    }
+}

--- a/android/src/main/res/layout/fingerprint_dialog.xml
+++ b/android/src/main/res/layout/fingerprint_dialog.xml
@@ -63,17 +63,37 @@
         android:textColor="#F00"
         android:textSize="15dp" />
 
-    <Button
-        android:id="@+id/cancel_button"
-        style="?android:attr/buttonBarButtonStyle"
+    <LinearLayout
+        android:id="@+id/buttonPanel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom|right"
-        android:paddingRight="15dp"
-        android:paddingLeft="15dp"
-        android:layout_marginEnd="10dp"
-        android:background="#fff"
-        android:text="Cancel"
-        android:textColor="#696969" />
+        android:orientation="horizontal" >
+
+        <Button
+            android:id="@+id/enter_keyguard_button"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="10dp"
+            android:background="#fff"
+            android:paddingLeft="35dp"
+            android:paddingRight="15dp"
+            android:text="Enter Passcode"
+            android:textColor="#696969" />
+
+        <Button
+            android:id="@+id/cancel_button"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|right"
+            android:layout_marginEnd="10dp"
+            android:background="#fff"
+            android:paddingLeft="15dp"
+            android:paddingRight="15dp"
+            android:text="Cancel"
+            android:textColor="#696969" />
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/android/src/main/res/layout/keyguard_dialog.xml
+++ b/android/src/main/res/layout/keyguard_dialog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</LinearLayout>


### PR DESCRIPTION
This PR includes the passcode fallback logic on both iOS and Android. We would prompt the user for passcode if the flag "passcodeFallback" is set to true.

On iOS, we would prompt the user for device passcode when user taps the "Enter passcode" button or when user fails the face ID for 2 times, touch ID for 3 times.

On Android, the "Enter passcode" button shows up after 1 unsuccessful attempt of fingerprint. We would prompt the user for device password/PIN/pattern(depends on what type of keyguard user configures on the device) when user taps the "Enter passcode" button or when user fails the fingerprint for 5 times.