### PR TITLE
Localise failed fingerprint attempt description message for android

### DIFF
--- a/TouchID.android.js
+++ b/TouchID.android.js
@@ -24,6 +24,7 @@ export default {
       imageErrorColor: '#ff0000',
       sensorDescription: 'Touch sensor',
       sensorErrorDescription: 'Failed',
+      sensorFailedDescription: 'Not recognized. Try again.',
       cancelText: 'Cancel',
       unifiedErrors: false
     };

--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -33,6 +33,7 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
     private String cancelText = "";
     private String sensorDescription = "";
     private String sensorErrorDescription = "";
+    private String sensorFailedDescription = "";
     private String errorText = "";
 
     @Override
@@ -40,6 +41,7 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
         super.onAttach(context);
 
         this.mFingerprintHandler = new FingerprintHandler(context, this);
+        this.mFingerprintHandler.setSensorFailedDescription(this.sensorFailedDescription);
     }
 
     @Override
@@ -152,6 +154,13 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
 
         if (config.hasKey("imageErrorColor")) {
             this.imageErrorColor = config.getInt("imageErrorColor");
+        }
+        
+        if (config.hasKey("sensorFailedDescription")) {
+            this.sensorFailedDescription = config.getString("sensorFailedDescription");
+            if(this.mFingerprintHandler != null) {
+                this.mFingerprintHandler.setSensorFailedDescription(this.sensorFailedDescription);
+            }
         }
     }
 

--- a/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
@@ -14,6 +14,8 @@ public class FingerprintHandler extends FingerprintManager.AuthenticationCallbac
 
     private final FingerprintManager mFingerprintManager;
     private final Callback mCallback;
+    
+    private String sensorFailedDescription = "";
 
     public FingerprintHandler(Context context, Callback callback) {
         mFingerprintManager = context.getSystemService(FingerprintManager.class);
@@ -40,7 +42,7 @@ public class FingerprintHandler extends FingerprintManager.AuthenticationCallbac
 
     @Override
     public void onAuthenticationFailed() {
-        mCallback.onError("Not recognized. Try again.", FingerprintAuthConstants.AUTHENTICATION_FAILED);
+        mCallback.onError(this.sensorFailedDescription, FingerprintAuthConstants.AUTHENTICATION_FAILED);
     }
 
     @Override
@@ -55,6 +57,10 @@ public class FingerprintHandler extends FingerprintManager.AuthenticationCallbac
             cancellationSignal.cancel();
             cancellationSignal = null;
         }
+    }
+
+    public void setSensorFailedDescription(String str) {
+        this.sensorFailedDescription = str;
     }
 
     public interface Callback {


### PR DESCRIPTION
As most of text values can be translated i'm adding support for the fingerprint failed description message for android.
![60950064-bf7ff780-a2f6-11e9-841a-2141e27dfbdc](https://user-images.githubusercontent.com/48120356/60973170-06d2ac00-a328-11e9-9952-f31815ba77ed.png)

