### PR TITLE
Update README.md (This might make confuse)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ import TouchID from 'react-native-touch-id';
 Requesting Face ID/Touch ID Authentication is as simple as calling:
 
 ```js
+const optionalConfigObject = {
+  unifiedErrors: false, // use unified error messages (default false)
+  passcodeFallback: false // if true is passed, itwill allow isSupported to return an error if the device is not enrolled in touch id/face id etc. Otherwise, it will just tell you what method is supported, even if the user is not enrolled.  (default false)
+}
+
 TouchID.authenticate('to demo this react-native component', optionalConfigObject)
   .then(success => {
     // Success code
@@ -213,7 +218,7 @@ Returns a `Promise` that rejects if TouchID is not supported. On iOS resolves wi
 
 ```js
 const optionalConfigObject = {
-  unifiedErrors: false // use unified error messages (default false)
+  unifiedErrors: false, // use unified error messages (default false)
   passcodeFallback: false // if true is passed, itwill allow isSupported to return an error if the device is not enrolled in touch id/face id etc. Otherwise, it will just tell you what method is supported, even if the user is not enrolled.  (default false)
 }
 


### PR DESCRIPTION
- Missing variable `optionalConfigObject` in requesting Face ID/Touch ID Authentication sample. (This might make confuse)
- Missing comma in optionalConfigObject object's variables. (This might make an error)