### PR TITLE
Make cancel button color customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Returns a `Promise` object.
   - `sensorDescription` - **Android** - text shown next to the fingerprint image
   - `sensorErrorDescription` - **Android** - text shown next to the fingerprint image after failed attempt
   - `cancelText` - **Android** - cancel button text
+  - `cancelTextColor` - **Android** - cancel button text color
+  - `cancelButtonColor` - **Android** - cancel button color
   - `fallbackLabel` - **iOS** - by default specified 'Show Password' label. If set to empty string label is invisible.
   - `unifiedErrors` - return unified error messages (see below) (default = false)
   - `passcodeFallback` - **iOS** - by default set to false. If set to true, will allow use of keypad passcode.
@@ -191,6 +193,8 @@ const optionalConfigObject = {
   sensorDescription: 'Touch sensor', // Android
   sensorErrorDescription: 'Failed', // Android
   cancelText: 'Cancel', // Android
+  cancelTextColor: '#ffffff', // Android
+  cancelButtonColor: '#e00606', // Android
   fallbackLabel: 'Show Passcode', // iOS (if empty, then label is hidden)
   unifiedErrors: false, // use unified error messages (default false)
   passcodeFallback: false, // iOS - allows the device to fall back to using the passcode, if faceid/touch is not available. this does not mean that if touchid/faceid fails the first few times it will revert to passcode, rather that if the former are not enrolled, then it will use the passcode.

--- a/TouchID.android.js
+++ b/TouchID.android.js
@@ -25,15 +25,21 @@ export default {
       sensorDescription: 'Touch sensor',
       sensorErrorDescription: 'Failed',
       cancelText: 'Cancel',
+      cancelTextColor: '#ffffff',
+      cancelButtonColor: '#6200ee',
       unifiedErrors: false
     };
     var authReason = reason ? reason : ' ';
     var authConfig = Object.assign({}, DEFAULT_CONFIG, config);
     var imageColor = processColor(authConfig.imageColor);
     var imageErrorColor = processColor(authConfig.imageErrorColor);
+    var cancelTextColor = processColor(authConfig.cancelTextColor);
+    var cancelButtonColor = processColor(authConfig.cancelButtonColor);
 
     authConfig.imageColor = imageColor;
     authConfig.imageErrorColor = imageErrorColor;
+    authConfig.cancelTextColor = cancelTextColor;
+    authConfig.cancelButtonColor = cancelButtonColor;
 
     return new Promise((resolve, reject) => {
       NativeTouchID.authenticate(

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,6 @@
 // Inspired by rayronvictor's PR #248 tp react-native-config
 // https://github.com/luggit/react-native-config/pull/248
 
-def _ext = rootProject.ext
-
 buildscript {
   repositories {
     maven {
@@ -14,17 +12,17 @@ buildscript {
   }
 
   dependencies {
-    classpath _ext.has('gradleBuildTools') ? _ext.gradleBuildTools : 'com.android.tools.build:gradle:3.4.0'
+    classpath rootProject.ext.has('gradleBuildTools') ? rootProject.ext.gradleBuildTools : 'com.android.tools.build:gradle:3.4.0'
   }
 }
 
 apply plugin: 'com.android.library'
 
-def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
-def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 27
-def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '27.0.3'
-def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
-def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 27
+def _reactNativeVersion = rootProject.ext.has('reactNative') ? rootProject.ext.reactNative : '+'
+def _compileSdkVersion = rootProject.ext.has('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 27
+def _buildToolsVersion = rootProject.ext.has('buildToolsVersion') ? rootProject.ext.buildToolsVersion : '27.0.3'
+def _minSdkVersion = rootProject.ext.has('minSdkVersion') ? rootProject.ext.minSdkVersion : 16
+def _targetSdkVersion = rootProject.ext.has('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 27
 
 android {
   compileSdkVersion _compileSdkVersion

--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -28,6 +28,8 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
 
     private String authReason;
     private int imageColor = 0;
+    private int cancelTextColor = 0;
+    private int cancelButtonColor = 0;
     private int imageErrorColor = 0;
     private String dialogTitle = "";
     private String cancelText = "";
@@ -68,6 +70,12 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
         this.mFingerprintError.setText(this.errorText);
 
         final Button mCancelButton = (Button) v.findViewById(R.id.cancel_button);
+        if (this.cancelTextColor != 0) {
+            mCancelButton.setTextColor(this.cancelTextColor);
+        }
+        if (this.cancelButtonColor != 0) {
+            mCancelButton.setBackgroundColor(this.cancelButtonColor);
+        }
         mCancelButton.setText(this.cancelText);
         mCancelButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -136,6 +144,14 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
 
         if (config.hasKey("cancelText")) {
             this.cancelText = config.getString("cancelText");
+        }
+
+        if (config.hasKey("cancelTextColor")) {
+            this.cancelTextColor = config.getInt("cancelTextColor");
+        }
+
+        if (config.hasKey("cancelButtonColor")) {
+            this.cancelButtonColor = config.getInt("cancelButtonColor");
         }
 
         if (config.hasKey("sensorDescription")) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,14 @@ declare module 'react-native-touch-id' {
        */
       cancelText?: string;
       /**
+       * **Android only** - Cancel button text color
+       */
+      cancelTextColor?: string;
+      /**
+       * **Android only** - Cancel button color
+       */
+      cancelButtonColor?: string;
+      /**
        * **iOS only** - By default specified 'Show Password' label. If set to empty string label is invisible.
        */
       fallbackLabel?: string;


### PR DESCRIPTION
This patch add cancelTextColor and cancelButtonColor options.
It also fixes the build with latest version of react native that can't find definition of `_ext`.